### PR TITLE
Pass build by refence in EntityViewEvent

### DIFF
--- a/src/Event/Entity/EntityViewEvent.php
+++ b/src/Event/Entity/EntityViewEvent.php
@@ -61,7 +61,7 @@ class EntityViewEvent extends BaseEntityEvent {
    * @return array
    *   The build.
    */
-  public function getBuild() {
+  public function &getBuild() {
     return $this->build;
   }
 


### PR DESCRIPTION
In the setBuild method there is a deprecated warning about the build beeing
passed by refence. This was a lie, now it really does.

@robiningelbrecht kan je deze even checken 🙂?