### PR TITLE
Event priority in form alter and widget form alter

### DIFF
--- a/hook_event_dispatcher.module
+++ b/hook_event_dispatcher.module
@@ -148,7 +148,6 @@ function hook_event_dispatcher_entity_view(array &$build, EntityInterface $entit
 function hook_event_dispatcher_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   /** @var \Drupal\hook_event_dispatcher\Manager\HookEventDispatcherManager $manager */
   $manager = Drupal::service('hook_event_dispatcher.manager');
-  $manager->register(new FormIdAlterEvent($form, $form_state, $form_id));
   $manager->register(new FormAlterEvent($form, $form_state, $form_id));
 
   $build_info = $form_state->getBuildInfo();
@@ -156,6 +155,7 @@ function hook_event_dispatcher_form_alter(&$form, FormStateInterface $form_state
     /** @var \Drupal\hook_event_dispatcher\Event\Form\FormBaseAlterEvent $event */
     $manager->register(new FormBaseAlterEvent($form, $form_state, $form_id, $build_info['base_form_id']));
   }
+  $manager->register(new FormIdAlterEvent($form, $form_state, $form_id));
 }
 
 /**

--- a/hook_event_dispatcher.module
+++ b/hook_event_dispatcher.module
@@ -166,8 +166,8 @@ function hook_event_dispatcher_form_alter(&$form, FormStateInterface $form_state
 function hook_event_dispatcher_field_widget_form_alter(&$element, FormStateInterface $form_state, $context) {
   /** @var \Drupal\hook_event_dispatcher\Manager\HookEventDispatcherManager $manager */
   $manager = Drupal::service('hook_event_dispatcher.manager');
-  $manager->register(new WidgetTypeFormAlterEvent($element, $form_state, $context));
   $manager->register(new WidgetFormAlterEvent($element, $form_state, $context));
+  $manager->register(new WidgetTypeFormAlterEvent($element, $form_state, $context));
 }
 
 /**


### PR DESCRIPTION
According to the Drupal documentation the alter is called first, then the base id alter and last the specific form id alter. Same for the widget form alter, alter first and then type form alter.