### PR TITLE
Feature/entity original

### DIFF
--- a/src/Event/Entity/EntityPresaveEvent.php
+++ b/src/Event/Entity/EntityPresaveEvent.php
@@ -12,6 +12,18 @@ use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
 class EntityPresaveEvent extends BaseEntityEvent {
 
   /**
+   * Get the original Entity.
+   *
+   * @see hook_entity_update()
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   *   The original entity.
+   */
+  public function getOriginalEntity() {
+    return $this->entity->original;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function getDispatcherType() {

--- a/src/Event/Entity/EntityUpdateEvent.php
+++ b/src/Event/Entity/EntityUpdateEvent.php
@@ -12,6 +12,18 @@ use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
 class EntityUpdateEvent extends BaseEntityEvent {
 
   /**
+   * Get the original Entity.
+   *
+   * @see hook_entity_update()
+   *
+   * @return \Drupal\Core\Entity\EntityInterface
+   *   The original entity.
+   */
+  public function getOriginalEntity() {
+    return $this->entity->original;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function getDispatcherType() {

--- a/tests/src/Unit/Entity/EntityEventTest.php
+++ b/tests/src/Unit/Entity/EntityEventTest.php
@@ -144,12 +144,15 @@ class EntityEventTest extends UnitTestCase {
    */
   public function testEntityPresaveEvent() {
     $entity = $this->createMock(EntityInterface::class);
+    $originalEntity = $this->createMock(EntityInterface::class);
+    $entity->original = $originalEntity;
 
     hook_event_dispatcher_entity_presave($entity);
 
     /* @var \Drupal\hook_event_dispatcher\Event\Entity\EntityPresaveEvent $event */
     $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::ENTITY_PRE_SAVE);
     $this->assertEquals($entity, $event->getEntity());
+    $this->assertEquals($originalEntity, $event->getOriginalEntity());
   }
 
   /**

--- a/tests/src/Unit/Entity/EntityEventTest.php
+++ b/tests/src/Unit/Entity/EntityEventTest.php
@@ -160,12 +160,15 @@ class EntityEventTest extends UnitTestCase {
    */
   public function testEntityUpdateEvent() {
     $entity = $this->createMock(EntityInterface::class);
+    $originalEntity = $this->createMock(EntityInterface::class);
+    $entity->original = $originalEntity;
 
     hook_event_dispatcher_entity_update($entity);
 
     /* @var \Drupal\hook_event_dispatcher\Event\Entity\EntityUpdateEvent $event */
     $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::ENTITY_UPDATE);
     $this->assertEquals($entity, $event->getEntity());
+    $this->assertEquals($originalEntity, $event->getOriginalEntity());
   }
 
   /**


### PR DESCRIPTION
The presave & update hook sets the original entity on the entity object as a dynamic field. This helper function on the event makes it easier to get the original entity.