### PR TITLE
Update EntityAccessEvent to work with multiple access results

### DIFF
--- a/src/Event/Entity/EntityAccessEvent.php
+++ b/src/Event/Entity/EntityAccessEvent.php
@@ -3,6 +3,7 @@
 namespace Drupal\hook_event_dispatcher\Event\Entity;
 
 use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Access\AccessResultNeutral;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
@@ -48,6 +49,7 @@ class EntityAccessEvent extends BaseEntityEvent {
 
     $this->operation = $operation;
     $this->account = $account;
+    $this->accessResult = new AccessResultNeutral();
   }
 
   /**
@@ -85,9 +87,21 @@ class EntityAccessEvent extends BaseEntityEvent {
    *
    * @param \Drupal\Core\Access\AccessResultInterface $accessResult
    *   The access result.
+   *
+   * @deprecated in favour of addAccessResult() which is more descriptive.
    */
   public function setAccessResult(AccessResultInterface $accessResult) {
-    $this->accessResult = $accessResult;
+    $this->addAccessResult($accessResult);
+  }
+
+  /**
+   * Add the access result.
+   *
+   * @param \Drupal\Core\Access\AccessResultInterface $accessResult
+   *   The access result.
+   */
+  public function addAccessResult(AccessResultInterface $accessResult) {
+    $this->accessResult = $this->accessResult->orIf($accessResult);
   }
 
   /**

--- a/tests/src/Unit/Entity/EntityAccessEventTest.php
+++ b/tests/src/Unit/Entity/EntityAccessEventTest.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Drupal\Tests\hook_event_dispatcher\Unit\Entity;
+
+use Drupal\Core\Access\AccessResultAllowed;
+use Drupal\Core\Access\AccessResultForbidden;
+use Drupal\Core\Access\AccessResultNeutral;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\hook_event_dispatcher\Event\Entity\EntityAccessEvent;
+use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\Tests\hook_event_dispatcher\Unit\HookEventDispatcherManagerSpy;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Class EntityAccessEventTest.
+ *
+ * @package Drupal\Tests\hook_event_dispatcher\Unit\Entity
+ *
+ * @group hook_event_dispatcher
+ */
+class EntityAccessEventTest extends UnitTestCase {
+
+  /**
+   * The manager.
+   *
+   * @var \Drupal\Tests\hook_event_dispatcher\Unit\HookEventDispatcherManagerSpy
+   */
+  private $manager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    $builder = new ContainerBuilder();
+    $this->manager = new HookEventDispatcherManagerSpy();
+    $builder->set('hook_event_dispatcher.manager', $this->manager);
+    $builder->compile();
+    \Drupal::setContainer($builder);
+  }
+
+  /**
+   * Deprecated setEntity method test.
+   *
+   * @deprecated should be removed when setEntity() method is removed.
+   */
+  public function testDeprecatedSetEntityMethod() {
+    $entity = $this->createMock(EntityInterface::class);
+    $operation = 'test';
+    $account = $this->createMock(AccountInterface::class);
+    $event = new EntityAccessEvent($entity, $operation, $account);
+
+    $otherEntity = $this->createMock(EntityInterface::class);
+    $event->setEntity($otherEntity);
+
+    $this->assertEquals($otherEntity, $event->getEntity());
+  }
+
+  /**
+   * EntityAccessEvent with no changes test.
+   */
+  public function testEntityAccessEventWithNoChanges() {
+    $entity = $this->createMock(EntityInterface::class);
+    $operation = 'test';
+    $account = $this->createMock(AccountInterface::class);
+
+    $hookAccessResult = hook_event_dispatcher_entity_access($entity, $operation, $account);
+
+    /* @var \Drupal\hook_event_dispatcher\Event\Entity\EntityAccessEvent $event */
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::ENTITY_ACCESS);
+    $this->assertSame($entity, $event->getEntity());
+    $this->assertSame($operation, $event->getOperation());
+    $this->assertSame($account, $event->getAccount());
+
+    $this->assertTrue($hookAccessResult->isNeutral());
+    $this->assertFalse($hookAccessResult->isAllowed());
+    $this->assertFalse($hookAccessResult->isForbidden());
+  }
+
+  /**
+   * EntityAccessEvent with deprecated setAccessResult test.
+   *
+   * @deprecated should be removed when setAccessResult method is removed.
+   */
+  public function testEntityAccessEventWithDeprecatedSetAccessResult() {
+    $accessResult = new AccessResultForbidden();
+    $this->manager->setEventCallbacks([
+      HookEventDispatcherEvents::ENTITY_ACCESS => function (EntityAccessEvent $event) use ($accessResult) {
+        $event->setAccessResult($accessResult);
+      },
+    ]);
+
+    $entity = $this->createMock(EntityInterface::class);
+    $operation = 'test';
+    $account = $this->createMock(AccountInterface::class);
+
+    $hookAccessResult = hook_event_dispatcher_entity_access($entity, $operation, $account);
+
+    $this->assertFalse($hookAccessResult->isNeutral());
+    $this->assertFalse($hookAccessResult->isAllowed());
+    $this->assertTrue($hookAccessResult->isForbidden());
+  }
+
+  /**
+   * EntityAccessEvent with neutral result test.
+   */
+  public function testEntityAccessEventNeutralResult() {
+    $accessResult = new AccessResultNeutral();
+    $this->manager->setEventCallbacks([
+      HookEventDispatcherEvents::ENTITY_ACCESS => function (EntityAccessEvent $event) use ($accessResult) {
+        $event->addAccessResult($accessResult);
+      },
+    ]);
+
+    $entity = $this->createMock(EntityInterface::class);
+    $operation = 'test';
+    $account = $this->createMock(AccountInterface::class);
+
+    $hookAccessResult = hook_event_dispatcher_entity_access($entity, $operation, $account);
+
+    $this->assertTrue($hookAccessResult->isNeutral());
+    $this->assertFalse($hookAccessResult->isAllowed());
+    $this->assertFalse($hookAccessResult->isForbidden());
+  }
+
+  /**
+   * EntityAccessEvent with allowed result test.
+   */
+  public function testEntityAccessEventAllowedResult() {
+    $accessResult = new AccessResultAllowed();
+    $this->manager->setEventCallbacks([
+      HookEventDispatcherEvents::ENTITY_ACCESS => function (EntityAccessEvent $event) use ($accessResult) {
+        $event->addAccessResult($accessResult);
+      },
+    ]);
+
+    $entity = $this->createMock(EntityInterface::class);
+    $operation = 'test';
+    $account = $this->createMock(AccountInterface::class);
+
+    $hookAccessResult = hook_event_dispatcher_entity_access($entity, $operation, $account);
+
+    $this->assertFalse($hookAccessResult->isNeutral());
+    $this->assertTrue($hookAccessResult->isAllowed());
+    $this->assertFalse($hookAccessResult->isForbidden());
+  }
+
+  /**
+   * EntityAccessEvent with forbidden result test.
+   */
+  public function testEntityAccessEventForbiddenResult() {
+    $accessResult = new AccessResultForbidden();
+    $this->manager->setEventCallbacks([
+      HookEventDispatcherEvents::ENTITY_ACCESS => function (EntityAccessEvent $event) use ($accessResult) {
+        $event->addAccessResult($accessResult);
+      },
+    ]);
+
+    $entity = $this->createMock(EntityInterface::class);
+    $operation = 'test';
+    $account = $this->createMock(AccountInterface::class);
+
+    $hookAccessResult = hook_event_dispatcher_entity_access($entity, $operation, $account);
+
+    $this->assertFalse($hookAccessResult->isNeutral());
+    $this->assertFalse($hookAccessResult->isAllowed());
+    $this->assertTrue($hookAccessResult->isForbidden());
+  }
+
+  /**
+   * EntityAccessEvent with combined results test.
+   *
+   * This simulates multiple event listeners adding their own access results to
+   * this event.
+   */
+  public function testEntityAccessEventCombinedResults() {
+    $accessResults = [
+      new AccessResultNeutral(),
+      new AccessResultAllowed(),
+      new AccessResultForbidden(),
+    ];
+    $this->manager->setEventCallbacks([
+      HookEventDispatcherEvents::ENTITY_ACCESS => function (EntityAccessEvent $event) use ($accessResults) {
+        foreach ($accessResults as $accessResult) {
+          $event->addAccessResult($accessResult);
+        }
+      },
+    ]);
+
+    $entity = $this->createMock(EntityInterface::class);
+    $operation = 'test';
+    $account = $this->createMock(AccountInterface::class);
+
+    $hookAccessResult = hook_event_dispatcher_entity_access($entity, $operation, $account);
+
+    $this->assertFalse($hookAccessResult->isNeutral());
+    $this->assertFalse($hookAccessResult->isAllowed());
+    $this->assertTrue($hookAccessResult->isForbidden());
+  }
+
+}

--- a/tests/src/Unit/Entity/EntityEventTest.php
+++ b/tests/src/Unit/Entity/EntityEventTest.php
@@ -40,35 +40,6 @@ class EntityEventTest extends UnitTestCase {
   }
 
   /**
-   * Test EntityAccessEvent.
-   */
-  public function testEntityAccessEvent() {
-    $accessResult = $this->createMock(AccessResultInterface::class);
-    $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::ENTITY_ACCESS => function (EntityAccessEvent $event) use ($accessResult) {
-        $event->setAccessResult($accessResult);
-      },
-    ]);
-
-    $entity = $this->createMock(EntityInterface::class);
-    $operation = 'test';
-    $account = $this->createMock(AccountInterface::class);
-
-    $hookAccessResult = hook_event_dispatcher_entity_access($entity, $operation, $account);
-
-    /* @var \Drupal\hook_event_dispatcher\Event\Entity\EntityAccessEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::ENTITY_ACCESS);
-    $this->assertEquals($entity, $event->getEntity());
-    $this->assertEquals($operation, $event->getOperation());
-    $this->assertEquals($account, $event->getAccount());
-    $this->assertEquals($accessResult, $hookAccessResult);
-
-    $newEntity = $this->createMock(EntityInterface::class);
-    $event->setEntity($newEntity);
-    $this->assertEquals($newEntity, $event->getEntity());
-  }
-
-  /**
    * Test EntityCreateEvent.
    */
   public function testEntityCreateEvent() {


### PR DESCRIPTION
Currently when multiple modules listen on an EntityAccessEvent and have
set an access result on it, the last access result is the one that
wins. Changed this to the way the EntityAccessControlHandler handles
multiple access results.

https://www.drupal.org/project/hook_event_dispatcher/issues/2977267