### PR TITLE
Move event constants to an interface

### DIFF
--- a/src/Event/Block/BlockBuildAlterEvent.php
+++ b/src/Event/Block/BlockBuildAlterEvent.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\hook_event_dispatcher\Event\Block;
 
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 
 /**
  * Class EntityInsertEvent.
@@ -15,7 +15,7 @@ class BlockBuildAlterEvent extends BaseBlockEvent {
    * {@inheritdoc}
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::BLOCK_BUILD_ALTER;
+    return HookEventDispatcherInterface::BLOCK_BUILD_ALTER;
   }
 
 }

--- a/src/Event/Entity/EntityAccessEvent.php
+++ b/src/Event/Entity/EntityAccessEvent.php
@@ -6,7 +6,7 @@ use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\Access\AccessResultNeutral;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 
 /**
  * Class EntityAccessEvent.
@@ -108,7 +108,7 @@ class EntityAccessEvent extends BaseEntityEvent {
    * {@inheritdoc}
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::ENTITY_ACCESS;
+    return HookEventDispatcherInterface::ENTITY_ACCESS;
   }
 
 }

--- a/src/Event/Entity/EntityCreateEvent.php
+++ b/src/Event/Entity/EntityCreateEvent.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\hook_event_dispatcher\Event\Entity;
 
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 
 /**
  * Class EntityCreateEvent.
@@ -15,7 +15,7 @@ class EntityCreateEvent extends BaseEntityEvent {
    * {@inheritdoc}
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::ENTITY_CREATE;
+    return HookEventDispatcherInterface::ENTITY_CREATE;
   }
 
 }

--- a/src/Event/Entity/EntityDeleteEvent.php
+++ b/src/Event/Entity/EntityDeleteEvent.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\hook_event_dispatcher\Event\Entity;
 
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 
 /**
  * Class EntityDeleteEvent.
@@ -15,7 +15,7 @@ class EntityDeleteEvent extends BaseEntityEvent {
    * {@inheritdoc}
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::ENTITY_DELETE;
+    return HookEventDispatcherInterface::ENTITY_DELETE;
   }
 
 }

--- a/src/Event/Entity/EntityInsertEvent.php
+++ b/src/Event/Entity/EntityInsertEvent.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\hook_event_dispatcher\Event\Entity;
 
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 
 /**
  * Class EntityInsertEvent.
@@ -15,7 +15,7 @@ class EntityInsertEvent extends BaseEntityEvent {
    * {@inheritdoc}
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::ENTITY_INSERT;
+    return HookEventDispatcherInterface::ENTITY_INSERT;
   }
 
 }

--- a/src/Event/Entity/EntityLoadEvent.php
+++ b/src/Event/Entity/EntityLoadEvent.php
@@ -3,7 +3,7 @@
 namespace Drupal\hook_event_dispatcher\Event\Entity;
 
 use Drupal\hook_event_dispatcher\Event\EventInterface;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -63,7 +63,7 @@ class EntityLoadEvent extends Event implements EventInterface {
    * {@inheritdoc}
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::ENTITY_LOAD;
+    return HookEventDispatcherInterface::ENTITY_LOAD;
   }
 
 }

--- a/src/Event/Entity/EntityPredeleteEvent.php
+++ b/src/Event/Entity/EntityPredeleteEvent.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\hook_event_dispatcher\Event\Entity;
 
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 
 /**
  * Class EntityPredeleteEvent.
@@ -15,7 +15,7 @@ class EntityPredeleteEvent extends BaseEntityEvent {
    * {@inheritdoc}
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::ENTITY_PRE_DELETE;
+    return HookEventDispatcherInterface::ENTITY_PRE_DELETE;
   }
 
 }

--- a/src/Event/Entity/EntityPresaveEvent.php
+++ b/src/Event/Entity/EntityPresaveEvent.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\hook_event_dispatcher\Event\Entity;
 
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 
 /**
  * Class EntityPresaveEvent.
@@ -27,7 +27,7 @@ class EntityPresaveEvent extends BaseEntityEvent {
    * {@inheritdoc}
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::ENTITY_PRE_SAVE;
+    return HookEventDispatcherInterface::ENTITY_PRE_SAVE;
   }
 
 }

--- a/src/Event/Entity/EntityUpdateEvent.php
+++ b/src/Event/Entity/EntityUpdateEvent.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\hook_event_dispatcher\Event\Entity;
 
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 
 /**
  * Class EntityUpdateEvent.
@@ -27,7 +27,7 @@ class EntityUpdateEvent extends BaseEntityEvent {
    * {@inheritdoc}
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::ENTITY_UPDATE;
+    return HookEventDispatcherInterface::ENTITY_UPDATE;
   }
 
 }

--- a/src/Event/Entity/EntityViewEvent.php
+++ b/src/Event/Entity/EntityViewEvent.php
@@ -4,7 +4,7 @@ namespace Drupal\hook_event_dispatcher\Event\Entity;
 
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 
 /**
  * Class EntityViewEvent.
@@ -101,7 +101,7 @@ class EntityViewEvent extends BaseEntityEvent {
    * {@inheritdoc}
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::ENTITY_VIEW;
+    return HookEventDispatcherInterface::ENTITY_VIEW;
   }
 
 }

--- a/src/Event/EntityExtra/EntityExtraFieldInfoAlterEvent.php
+++ b/src/Event/EntityExtra/EntityExtraFieldInfoAlterEvent.php
@@ -3,7 +3,7 @@
 namespace Drupal\hook_event_dispatcher\Event\EntityExtra;
 
 use Drupal\hook_event_dispatcher\Event\EventInterface;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -37,7 +37,7 @@ class EntityExtraFieldInfoAlterEvent extends Event implements EventInterface {
    *   The dispatcher type.
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::ENTITY_EXTRA_FIELD_INFO_ALTER;
+    return HookEventDispatcherInterface::ENTITY_EXTRA_FIELD_INFO_ALTER;
   }
 
   /**

--- a/src/Event/EntityExtra/EntityExtraFieldInfoEvent.php
+++ b/src/Event/EntityExtra/EntityExtraFieldInfoEvent.php
@@ -3,7 +3,7 @@
 namespace Drupal\hook_event_dispatcher\Event\EntityExtra;
 
 use Drupal\hook_event_dispatcher\Event\EventInterface;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -27,7 +27,7 @@ class EntityExtraFieldInfoEvent extends Event implements EventInterface {
    *   The dispatcher type.
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::ENTITY_EXTRA_FIELD_INFO;
+    return HookEventDispatcherInterface::ENTITY_EXTRA_FIELD_INFO;
   }
 
   /**

--- a/src/Event/EntityField/EntityFieldAccessEvent.php
+++ b/src/Event/EntityField/EntityFieldAccessEvent.php
@@ -8,7 +8,7 @@ use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\hook_event_dispatcher\Event\EventInterface;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -76,7 +76,7 @@ class EntityFieldAccessEvent extends Event implements EventInterface {
    * {@inheritdoc}
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::ENTITY_FIELD_ACCESS;
+    return HookEventDispatcherInterface::ENTITY_FIELD_ACCESS;
   }
 
   /**

--- a/src/Event/EntityType/EntityBaseFieldInfoEvent.php
+++ b/src/Event/EntityType/EntityBaseFieldInfoEvent.php
@@ -4,7 +4,7 @@ namespace Drupal\hook_event_dispatcher\Event\EntityType;
 
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\hook_event_dispatcher\Event\EventInterface;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -42,7 +42,7 @@ class EntityBaseFieldInfoEvent extends Event implements EventInterface {
    * {@inheritdoc}
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::ENTITY_BASE_FIELD_INFO;
+    return HookEventDispatcherInterface::ENTITY_BASE_FIELD_INFO;
   }
 
   /**

--- a/src/Event/Form/FormAlterEvent.php
+++ b/src/Event/Form/FormAlterEvent.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\hook_event_dispatcher\Event\Form;
 
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 
 /**
  * Class FormAlterEvent.
@@ -15,7 +15,7 @@ class FormAlterEvent extends BaseFormEvent {
    * {@inheritdoc}
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::FORM_ALTER;
+    return HookEventDispatcherInterface::FORM_ALTER;
   }
 
 }

--- a/src/Event/Form/WidgetFormAlterEvent.php
+++ b/src/Event/Form/WidgetFormAlterEvent.php
@@ -4,7 +4,7 @@ namespace Drupal\hook_event_dispatcher\Event\Form;
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\hook_event_dispatcher\Event\EventInterface;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -103,7 +103,7 @@ class WidgetFormAlterEvent extends Event implements EventInterface {
    * {@inheritdoc}
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::WIDGET_FORM_ALTER;
+    return HookEventDispatcherInterface::WIDGET_FORM_ALTER;
   }
 
 }

--- a/src/Event/Path/PathDeleteEvent.php
+++ b/src/Event/Path/PathDeleteEvent.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\hook_event_dispatcher\Event\Path;
 
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 
 /**
  * Class PathDeleteEvent.
@@ -46,7 +46,7 @@ final class PathDeleteEvent extends BasePathEvent {
    *   The dispatcher type.
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::PATH_DELETE;
+    return HookEventDispatcherInterface::PATH_DELETE;
   }
 
 }

--- a/src/Event/Path/PathInsertEvent.php
+++ b/src/Event/Path/PathInsertEvent.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\hook_event_dispatcher\Event\Path;
 
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 
 /**
  * Class PathInsertEvent.
@@ -18,7 +18,7 @@ final class PathInsertEvent extends BasePathEvent {
    *   The dispatcher type.
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::PATH_INSERT;
+    return HookEventDispatcherInterface::PATH_INSERT;
   }
 
 }

--- a/src/Event/Path/PathUpdateEvent.php
+++ b/src/Event/Path/PathUpdateEvent.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\hook_event_dispatcher\Event\Path;
 
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 
 /**
  * Class UpdatePathEvent.
@@ -18,7 +18,7 @@ final class PathUpdateEvent extends BasePathEvent {
    *   The dispatcher type.
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::PATH_UPDATE;
+    return HookEventDispatcherInterface::PATH_UPDATE;
   }
 
 }

--- a/src/Event/Theme/JsAlterEvent.php
+++ b/src/Event/Theme/JsAlterEvent.php
@@ -4,7 +4,7 @@ namespace Drupal\hook_event_dispatcher\Event\Theme;
 
 use Drupal\Core\Asset\AttachedAssetsInterface;
 use Drupal\hook_event_dispatcher\Event\EventInterface;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -81,7 +81,7 @@ final class JsAlterEvent extends Event implements EventInterface {
    *   The dispatcher type.
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::JS_ALTER;
+    return HookEventDispatcherInterface::JS_ALTER;
   }
 
 }

--- a/src/Event/Theme/TemplatePreprocessDefaultVariablesAlterEvent.php
+++ b/src/Event/Theme/TemplatePreprocessDefaultVariablesAlterEvent.php
@@ -3,7 +3,7 @@
 namespace Drupal\hook_event_dispatcher\Event\Theme;
 
 use Drupal\hook_event_dispatcher\Event\EventInterface;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -40,7 +40,7 @@ final class TemplatePreprocessDefaultVariablesAlterEvent extends Event implement
    *   The dispatcher type.
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::TEMPLATE_PREPROCESS_DEFAULT_VARIABLES_ALTER;
+    return HookEventDispatcherInterface::TEMPLATE_PREPROCESS_DEFAULT_VARIABLES_ALTER;
   }
 
   /**

--- a/src/Event/Theme/ThemeEvent.php
+++ b/src/Event/Theme/ThemeEvent.php
@@ -3,7 +3,7 @@
 namespace Drupal\hook_event_dispatcher\Event\Theme;
 
 use Drupal\hook_event_dispatcher\Event\EventInterface;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -49,7 +49,7 @@ final class ThemeEvent extends Event implements EventInterface {
    *   The dispatcher type.
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::THEME;
+    return HookEventDispatcherInterface::THEME;
   }
 
   /**

--- a/src/Event/Theme/ThemeSuggestionsAlterEvent.php
+++ b/src/Event/Theme/ThemeSuggestionsAlterEvent.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\hook_event_dispatcher\Event\Theme;
 
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 
 /**
  * Class ThemeSuggestionsAlterEvent.
@@ -18,7 +18,7 @@ class ThemeSuggestionsAlterEvent extends BaseThemeSuggestionsEvent {
    *   Dispatcher type.
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::THEME_SUGGESTIONS_ALTER;
+    return HookEventDispatcherInterface::THEME_SUGGESTIONS_ALTER;
   }
 
 }

--- a/src/Event/Token/TokensInfoEvent.php
+++ b/src/Event/Token/TokensInfoEvent.php
@@ -3,7 +3,7 @@
 namespace Drupal\hook_event_dispatcher\Event\Token;
 
 use Drupal\hook_event_dispatcher\Event\EventInterface;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Drupal\hook_event_dispatcher\Value\Token;
 use Drupal\hook_event_dispatcher\Value\TokenType;
 use Symfony\Component\EventDispatcher\Event;
@@ -111,7 +111,7 @@ final class TokensInfoEvent extends Event implements EventInterface {
    *   The dispatcher type.
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::TOKEN_INFO;
+    return HookEventDispatcherInterface::TOKEN_INFO;
   }
 
 }

--- a/src/Event/Token/TokensReplacementEvent.php
+++ b/src/Event/Token/TokensReplacementEvent.php
@@ -5,7 +5,7 @@ namespace Drupal\hook_event_dispatcher\Event\Token;
 use Drupal\Component\Render\MarkupInterface;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\hook_event_dispatcher\Event\EventInterface;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -234,7 +234,7 @@ final class TokensReplacementEvent extends Event implements EventInterface {
    * {@inheritdoc}
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::TOKEN_REPLACEMENT;
+    return HookEventDispatcherInterface::TOKEN_REPLACEMENT;
   }
 
   /**

--- a/src/Event/Toolbar/ToolbarAlterEvent.php
+++ b/src/Event/Toolbar/ToolbarAlterEvent.php
@@ -3,7 +3,7 @@
 namespace Drupal\hook_event_dispatcher\Event\Toolbar;
 
 use Drupal\hook_event_dispatcher\Event\EventInterface;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -54,7 +54,7 @@ class ToolbarAlterEvent extends Event implements EventInterface {
    * {@inheritdoc}
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::TOOLBAR_ALTER;
+    return HookEventDispatcherInterface::TOOLBAR_ALTER;
   }
 
 }

--- a/src/Event/User/UserFormatNameAlterEvent.php
+++ b/src/Event/User/UserFormatNameAlterEvent.php
@@ -4,7 +4,7 @@ namespace Drupal\hook_event_dispatcher\Event\User;
 
 use Drupal\Core\Session\AccountInterface;
 use Drupal\hook_event_dispatcher\Event\EventInterface;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -78,7 +78,7 @@ final class UserFormatNameAlterEvent extends Event implements EventInterface {
    *   The dispatcher type.
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::USER_FORMAT_NAME_ALTER;
+    return HookEventDispatcherInterface::USER_FORMAT_NAME_ALTER;
   }
 
 }

--- a/src/Event/User/UserLoginEvent.php
+++ b/src/Event/User/UserLoginEvent.php
@@ -4,7 +4,7 @@ namespace Drupal\hook_event_dispatcher\Event\User;
 
 use Drupal\Core\Session\AccountInterface;
 use Drupal\hook_event_dispatcher\Event\EventInterface;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -48,7 +48,7 @@ final class UserLoginEvent extends Event implements EventInterface {
    *   The dispatcher type.
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::USER_LOGIN;
+    return HookEventDispatcherInterface::USER_LOGIN;
   }
 
 }

--- a/src/Event/User/UserLogoutEvent.php
+++ b/src/Event/User/UserLogoutEvent.php
@@ -4,7 +4,7 @@ namespace Drupal\hook_event_dispatcher\Event\User;
 
 use Drupal\Core\Session\AccountInterface;
 use Drupal\hook_event_dispatcher\Event\EventInterface;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -48,7 +48,7 @@ final class UserLogoutEvent extends Event implements EventInterface {
    *   The dispatcher type.
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::USER_LOGOUT;
+    return HookEventDispatcherInterface::USER_LOGOUT;
   }
 
 }

--- a/src/Event/Views/ViewsDataAlterEvent.php
+++ b/src/Event/Views/ViewsDataAlterEvent.php
@@ -3,7 +3,7 @@
 namespace Drupal\hook_event_dispatcher\Event\Views;
 
 use Drupal\hook_event_dispatcher\Event\EventInterface;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -57,7 +57,7 @@ final class ViewsDataAlterEvent extends Event implements EventInterface {
    *   The dispatcher type.
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::VIEWS_DATA_ALTER;
+    return HookEventDispatcherInterface::VIEWS_DATA_ALTER;
   }
 
 }

--- a/src/Event/Views/ViewsDataEvent.php
+++ b/src/Event/Views/ViewsDataEvent.php
@@ -3,7 +3,7 @@
 namespace Drupal\hook_event_dispatcher\Event\Views;
 
 use Drupal\hook_event_dispatcher\Event\EventInterface;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -49,7 +49,7 @@ final class ViewsDataEvent extends Event implements EventInterface {
    *   The dispatcher type.
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::VIEWS_DATA;
+    return HookEventDispatcherInterface::VIEWS_DATA;
   }
 
 }

--- a/src/Event/Views/ViewsPostBuildEvent.php
+++ b/src/Event/Views/ViewsPostBuildEvent.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\hook_event_dispatcher\Event\Views;
 
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 
 /**
  * Class ViewsPostBuildEvent.
@@ -15,7 +15,7 @@ class ViewsPostBuildEvent extends BaseViewsEvent {
    * {@inheritdoc}
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::VIEWS_POST_BUILD;
+    return HookEventDispatcherInterface::VIEWS_POST_BUILD;
   }
 
 }

--- a/src/Event/Views/ViewsPostExecuteEvent.php
+++ b/src/Event/Views/ViewsPostExecuteEvent.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\hook_event_dispatcher\Event\Views;
 
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 
 /**
  * Class ViewsPostExecuteEvent.
@@ -15,7 +15,7 @@ class ViewsPostExecuteEvent extends BaseViewsEvent {
    * {@inheritdoc}
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::VIEWS_POST_EXECUTE;
+    return HookEventDispatcherInterface::VIEWS_POST_EXECUTE;
   }
 
 }

--- a/src/Event/Views/ViewsPreBuildEvent.php
+++ b/src/Event/Views/ViewsPreBuildEvent.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\hook_event_dispatcher\Event\Views;
 
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 
 /**
  * Class ViewsPreBuildEvent.
@@ -15,7 +15,7 @@ class ViewsPreBuildEvent extends BaseViewsEvent {
    * {@inheritdoc}
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::VIEWS_PRE_BUILD;
+    return HookEventDispatcherInterface::VIEWS_PRE_BUILD;
   }
 
 }

--- a/src/Event/Views/ViewsPreExecuteEvent.php
+++ b/src/Event/Views/ViewsPreExecuteEvent.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\hook_event_dispatcher\Event\Views;
 
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 
 /**
  * Class ViewsPreExecuteEvent.
@@ -15,7 +15,7 @@ class ViewsPreExecuteEvent extends BaseViewsEvent {
    * {@inheritdoc}
    */
   public function getDispatcherType() {
-    return HookEventDispatcherEvents::VIEWS_PRE_EXECUTE;
+    return HookEventDispatcherInterface::VIEWS_PRE_EXECUTE;
   }
 
 }

--- a/src/Example/ExampleEntityEventSubscribers.php
+++ b/src/Example/ExampleEntityEventSubscribers.php
@@ -8,7 +8,7 @@ use Drupal\hook_event_dispatcher\Event\Entity\EntityPredeleteEvent;
 use Drupal\hook_event_dispatcher\Event\Entity\EntityPresaveEvent;
 use Drupal\hook_event_dispatcher\Event\Entity\EntityUpdateEvent;
 use Drupal\hook_event_dispatcher\Event\Entity\EntityViewEvent;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Drupal\node\NodeInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -110,12 +110,12 @@ class ExampleEntityEventSubscribers implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return [
-      HookEventDispatcherEvents::ENTITY_VIEW => 'alterEntityView',
-      HookEventDispatcherEvents::ENTITY_PRE_SAVE => 'entityPreSave',
-      HookEventDispatcherEvents::ENTITY_INSERT => 'entityInsert',
-      HookEventDispatcherEvents::ENTITY_UPDATE => 'entityUpdate',
-      HookEventDispatcherEvents::ENTITY_PRE_DELETE => 'entityPreDelete',
-      HookEventDispatcherEvents::ENTITY_DELETE => 'entityDelete',
+      HookEventDispatcherInterface::ENTITY_VIEW => 'alterEntityView',
+      HookEventDispatcherInterface::ENTITY_PRE_SAVE => 'entityPreSave',
+      HookEventDispatcherInterface::ENTITY_INSERT => 'entityInsert',
+      HookEventDispatcherInterface::ENTITY_UPDATE => 'entityUpdate',
+      HookEventDispatcherInterface::ENTITY_PRE_DELETE => 'entityPreDelete',
+      HookEventDispatcherInterface::ENTITY_DELETE => 'entityDelete',
     ];
   }
 

--- a/src/Example/ExampleEntityExtraFieldInfoSubscribers.php
+++ b/src/Example/ExampleEntityExtraFieldInfoSubscribers.php
@@ -4,7 +4,7 @@ namespace Drupal\hook_event_dispatcher\Example;
 
 use Drupal\hook_event_dispatcher\Event\EntityExtra\EntityExtraFieldInfoAlterEvent;
 use Drupal\hook_event_dispatcher\Event\EntityExtra\EntityExtraFieldInfoEvent;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -63,8 +63,8 @@ class ExampleEntityExtraFieldInfoSubscribers implements EventSubscriberInterface
    */
   public static function getSubscribedEvents() {
     return [
-      HookEventDispatcherEvents::ENTITY_EXTRA_FIELD_INFO => 'fieldInfo',
-      HookEventDispatcherEvents::ENTITY_EXTRA_FIELD_INFO_ALTER => 'fieldInfoAlter',
+      HookEventDispatcherInterface::ENTITY_EXTRA_FIELD_INFO => 'fieldInfo',
+      HookEventDispatcherInterface::ENTITY_EXTRA_FIELD_INFO_ALTER => 'fieldInfoAlter',
     ];
   }
 

--- a/src/Example/ExampleFormEventSubscribers.php
+++ b/src/Example/ExampleFormEventSubscribers.php
@@ -7,7 +7,7 @@ use Drupal\hook_event_dispatcher\Event\Form\FormBaseAlterEvent;
 use Drupal\hook_event_dispatcher\Event\Form\FormIdAlterEvent;
 use Drupal\hook_event_dispatcher\Event\Form\WidgetFormAlterEvent;
 use Drupal\hook_event_dispatcher\Event\Form\WidgetTypeFormAlterEvent;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -97,7 +97,7 @@ class ExampleFormEventSubscribers implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return [
-      HookEventDispatcherEvents::FORM_ALTER => 'alterForm',
+      HookEventDispatcherInterface::FORM_ALTER => 'alterForm',
       // React on "search_block_form" form.
       'hook_event_dispatcher.form_search_block_form.alter' => 'alterSearchForm',
       // React on al forms with base id "node_form".

--- a/src/Example/ExampleTokenEventSubscriber.php
+++ b/src/Example/ExampleTokenEventSubscriber.php
@@ -4,7 +4,7 @@ namespace Drupal\hook_event_dispatcher\Example;
 
 use Drupal\hook_event_dispatcher\Event\Token\TokensInfoEvent;
 use Drupal\hook_event_dispatcher\Event\Token\TokensReplacementEvent;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Drupal\hook_event_dispatcher\Value\Token;
 use Drupal\hook_event_dispatcher\Value\TokenType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -19,8 +19,8 @@ final class ExampleTokenEventSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return [
-      HookEventDispatcherEvents::TOKEN_REPLACEMENT => 'tokenReplacement',
-      HookEventDispatcherEvents::TOKEN_INFO => 'tokenInfo',
+      HookEventDispatcherInterface::TOKEN_REPLACEMENT => 'tokenReplacement',
+      HookEventDispatcherInterface::TOKEN_INFO => 'tokenInfo',
     ];
   }
 

--- a/src/Example/ExampleViewsEventSubscribers.php
+++ b/src/Example/ExampleViewsEventSubscribers.php
@@ -6,7 +6,7 @@ use Drupal\hook_event_dispatcher\Event\Views\ViewsPostBuildEvent;
 use Drupal\hook_event_dispatcher\Event\Views\ViewsPostExecuteEvent;
 use Drupal\hook_event_dispatcher\Event\Views\ViewsPreBuildEvent;
 use Drupal\hook_event_dispatcher\Event\Views\ViewsPreExecuteEvent;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -82,10 +82,10 @@ class ExampleViewsEventSubscribers implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return [
-      HookEventDispatcherEvents::VIEWS_PRE_BUILD => 'preBuild',
-      HookEventDispatcherEvents::VIEWS_POST_BUILD => 'postBuild',
-      HookEventDispatcherEvents::VIEWS_PRE_EXECUTE => 'preExecute',
-      HookEventDispatcherEvents::VIEWS_POST_EXECUTE => 'postExecute',
+      HookEventDispatcherInterface::VIEWS_PRE_BUILD => 'preBuild',
+      HookEventDispatcherInterface::VIEWS_POST_BUILD => 'postBuild',
+      HookEventDispatcherInterface::VIEWS_PRE_EXECUTE => 'preExecute',
+      HookEventDispatcherInterface::VIEWS_POST_EXECUTE => 'postExecute',
     ];
   }
 

--- a/src/HookEventDispatcherEvents.php
+++ b/src/HookEventDispatcherEvents.php
@@ -6,66 +6,7 @@ namespace Drupal\hook_event_dispatcher;
  * Class HookEventDispatcherEvents.
  *
  * @package Drupal\hook_event_dispatcher
+ *
+ * @deprecated in favour of the HookEventDispatcherEventsInterface.
  */
-final class HookEventDispatcherEvents {
-
-  // ENTITY EVENTS.
-  const ENTITY_INSERT = 'hook_event_dispatcher.entity.insert';
-  const ENTITY_UPDATE = 'hook_event_dispatcher.entity.update';
-  const ENTITY_PRE_DELETE = 'hook_event_dispatcher.entity.predelete';
-  const ENTITY_DELETE = 'hook_event_dispatcher.entity.delete';
-  const ENTITY_PRE_SAVE = 'hook_event_dispatcher.entity.presave';
-  const ENTITY_VIEW = 'hook_event_dispatcher.entity.view';
-  const ENTITY_ACCESS = 'hook_event_dispatcher.entity.access';
-  const ENTITY_CREATE = 'hook_event_dispatcher.entity.create';
-  const ENTITY_LOAD = 'hook_event_dispatcher.entity.load';
-
-  // ENTITY FIELD EVENTS.
-  const ENTITY_FIELD_ACCESS = 'hook_event_dispatcher.entity_field.access';
-
-  // ENTITY EXTRA FIELD EVENTS.
-  const ENTITY_EXTRA_FIELD_INFO_ALTER = 'hook_event_dispatcher.entity_extra_field.info';
-  const ENTITY_EXTRA_FIELD_INFO = 'hook_event_dispatcher.entity_extra_field.info_alter';
-
-  // ENTITY TYPE EVENTS.
-  const ENTITY_BASE_FIELD_INFO = 'hook_event_dispatcher.entity_base.field_info';
-
-  // FORM EVENTS.
-  const FORM_ALTER = 'hook_event_dispatcher.form.alter';
-  const WIDGET_FORM_ALTER = 'hook_event_dispatcher.widget_form.alter';
-
-  // BLOCK EVENTS.
-  const BLOCK_BUILD_ALTER = 'hook_event_dispatcher.block_build.alter';
-
-  // TOKEN EVENTS.
-  const TOKEN_REPLACEMENT = 'hook_event_dispatcher.token.replacement';
-  const TOKEN_INFO = 'hook_event_dispatcher.token.info';
-
-  // PATH EVENTS.
-  const PATH_INSERT = 'hook_event_dispatcher.path.insert';
-  const PATH_DELETE = 'hook_event_dispatcher.path.delete';
-  const PATH_UPDATE = 'hook_event_dispatcher.path.update';
-
-  // VIEWS EVENTS.
-  const VIEWS_DATA = 'hook_event_dispatcher.views.data';
-  const VIEWS_DATA_ALTER = 'hook_event_dispatcher.views.data_alter';
-  const VIEWS_PRE_EXECUTE = 'hook_event_dispatcher.views.pre_execute';
-  const VIEWS_POST_EXECUTE = 'hook_event_dispatcher.views.post_execute';
-  const VIEWS_PRE_BUILD = 'hook_event_dispatcher.views.pre_build';
-  const VIEWS_POST_BUILD = 'hook_event_dispatcher.views.post_build';
-
-  // THEME EVENTS.
-  const THEME = 'hook_event_dispatcher.theme';
-  const THEME_SUGGESTIONS_ALTER = 'hook_event_dispatcher.theme.suggestions_alter';
-  const TEMPLATE_PREPROCESS_DEFAULT_VARIABLES_ALTER = 'hook_event_dispatcher.theme.template_preprocess_default_variables_alter';
-  const JS_ALTER = 'hook_event_dispatcher.js.alter';
-
-  // USER EVENTS.
-  const USER_LOGIN = 'hook_event_dispatcher.user.login';
-  const USER_LOGOUT = 'hook_event_dispatcher.user.logout';
-  const USER_FORMAT_NAME_ALTER = 'hook_event_dispatcher.user.format_name_alter';
-
-  // TOOLBAR EVENTS.
-  const TOOLBAR_ALTER = 'hook_event_dispatcher.toolbar.alter';
-
-}
+final class HookEventDispatcherEvents implements HookEventDispatcherInterface {}

--- a/src/HookEventDispatcherInterface.php
+++ b/src/HookEventDispatcherInterface.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\hook_event_dispatcher;
+
+/**
+ * Interface HookEventDispatcherEventsInterface.
+ *
+ * @package Drupal\hook_event_dispatcher
+ */
+interface HookEventDispatcherInterface {
+
+  // ENTITY EVENTS.
+  const ENTITY_INSERT = 'hook_event_dispatcher.entity.insert';
+  const ENTITY_UPDATE = 'hook_event_dispatcher.entity.update';
+  const ENTITY_PRE_DELETE = 'hook_event_dispatcher.entity.predelete';
+  const ENTITY_DELETE = 'hook_event_dispatcher.entity.delete';
+  const ENTITY_PRE_SAVE = 'hook_event_dispatcher.entity.presave';
+  const ENTITY_VIEW = 'hook_event_dispatcher.entity.view';
+  const ENTITY_ACCESS = 'hook_event_dispatcher.entity.access';
+  const ENTITY_CREATE = 'hook_event_dispatcher.entity.create';
+  const ENTITY_LOAD = 'hook_event_dispatcher.entity.load';
+
+  // ENTITY FIELD EVENTS.
+  const ENTITY_FIELD_ACCESS = 'hook_event_dispatcher.entity_field.access';
+
+  // ENTITY EXTRA FIELD EVENTS.
+  const ENTITY_EXTRA_FIELD_INFO_ALTER = 'hook_event_dispatcher.entity_extra_field.info';
+  const ENTITY_EXTRA_FIELD_INFO = 'hook_event_dispatcher.entity_extra_field.info_alter';
+
+  // ENTITY TYPE EVENTS.
+  const ENTITY_BASE_FIELD_INFO = 'hook_event_dispatcher.entity_base.field_info';
+
+  // FORM EVENTS.
+  const FORM_ALTER = 'hook_event_dispatcher.form.alter';
+  const WIDGET_FORM_ALTER = 'hook_event_dispatcher.widget_form.alter';
+
+  // BLOCK EVENTS.
+  const BLOCK_BUILD_ALTER = 'hook_event_dispatcher.block_build.alter';
+
+  // TOKEN EVENTS.
+  const TOKEN_REPLACEMENT = 'hook_event_dispatcher.token.replacement';
+  const TOKEN_INFO = 'hook_event_dispatcher.token.info';
+
+  // PATH EVENTS.
+  const PATH_INSERT = 'hook_event_dispatcher.path.insert';
+  const PATH_DELETE = 'hook_event_dispatcher.path.delete';
+  const PATH_UPDATE = 'hook_event_dispatcher.path.update';
+
+  // VIEWS EVENTS.
+  const VIEWS_DATA = 'hook_event_dispatcher.views.data';
+  const VIEWS_DATA_ALTER = 'hook_event_dispatcher.views.data_alter';
+  const VIEWS_PRE_EXECUTE = 'hook_event_dispatcher.views.pre_execute';
+  const VIEWS_POST_EXECUTE = 'hook_event_dispatcher.views.post_execute';
+  const VIEWS_PRE_BUILD = 'hook_event_dispatcher.views.pre_build';
+  const VIEWS_POST_BUILD = 'hook_event_dispatcher.views.post_build';
+
+  // THEME EVENTS.
+  const THEME = 'hook_event_dispatcher.theme';
+  const THEME_SUGGESTIONS_ALTER = 'hook_event_dispatcher.theme.suggestions_alter';
+  const TEMPLATE_PREPROCESS_DEFAULT_VARIABLES_ALTER = 'hook_event_dispatcher.theme.template_preprocess_default_variables_alter';
+  const JS_ALTER = 'hook_event_dispatcher.js.alter';
+
+  // USER EVENTS.
+  const USER_LOGIN = 'hook_event_dispatcher.user.login';
+  const USER_LOGOUT = 'hook_event_dispatcher.user.logout';
+  const USER_FORMAT_NAME_ALTER = 'hook_event_dispatcher.user.format_name_alter';
+
+  // TOOLBAR EVENTS.
+  const TOOLBAR_ALTER = 'hook_event_dispatcher.toolbar.alter';
+
+}

--- a/tests/src/Unit/Block/BlockEventTest.php
+++ b/tests/src/Unit/Block/BlockEventTest.php
@@ -4,7 +4,7 @@ namespace Drupal\Tests\hook_event_dispatcher\Unit\Block;
 
 use Drupal\Core\Block\BlockPluginInterface;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Drupal\Tests\hook_event_dispatcher\Unit\HookEventDispatcherManagerSpy;
 use Drupal\Tests\UnitTestCase;
 
@@ -45,7 +45,7 @@ class BlockEventTest extends UnitTestCase {
     hook_event_dispatcher_block_build_alter($build, $block);
 
     /* @var \Drupal\hook_event_dispatcher\Event\Block\BlockBuildAlterEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::BLOCK_BUILD_ALTER);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::BLOCK_BUILD_ALTER);
     $this->assertEquals($build, $event->getBuild());
     $this->assertEquals($block, $event->getBlock());
 

--- a/tests/src/Unit/Entity/EntityAccessEventTest.php
+++ b/tests/src/Unit/Entity/EntityAccessEventTest.php
@@ -9,7 +9,7 @@ use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\hook_event_dispatcher\Event\Entity\EntityAccessEvent;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Drupal\Tests\hook_event_dispatcher\Unit\HookEventDispatcherManagerSpy;
 use Drupal\Tests\UnitTestCase;
 
@@ -68,7 +68,7 @@ class EntityAccessEventTest extends UnitTestCase {
     $hookAccessResult = hook_event_dispatcher_entity_access($entity, $operation, $account);
 
     /* @var \Drupal\hook_event_dispatcher\Event\Entity\EntityAccessEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::ENTITY_ACCESS);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::ENTITY_ACCESS);
     $this->assertSame($entity, $event->getEntity());
     $this->assertSame($operation, $event->getOperation());
     $this->assertSame($account, $event->getAccount());
@@ -86,7 +86,7 @@ class EntityAccessEventTest extends UnitTestCase {
   public function testEntityAccessEventWithDeprecatedSetAccessResult() {
     $accessResult = new AccessResultForbidden();
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::ENTITY_ACCESS => function (EntityAccessEvent $event) use ($accessResult) {
+      HookEventDispatcherInterface::ENTITY_ACCESS => function (EntityAccessEvent $event) use ($accessResult) {
         $event->setAccessResult($accessResult);
       },
     ]);
@@ -108,7 +108,7 @@ class EntityAccessEventTest extends UnitTestCase {
   public function testEntityAccessEventNeutralResult() {
     $accessResult = new AccessResultNeutral();
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::ENTITY_ACCESS => function (EntityAccessEvent $event) use ($accessResult) {
+      HookEventDispatcherInterface::ENTITY_ACCESS => function (EntityAccessEvent $event) use ($accessResult) {
         $event->addAccessResult($accessResult);
       },
     ]);
@@ -130,7 +130,7 @@ class EntityAccessEventTest extends UnitTestCase {
   public function testEntityAccessEventAllowedResult() {
     $accessResult = new AccessResultAllowed();
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::ENTITY_ACCESS => function (EntityAccessEvent $event) use ($accessResult) {
+      HookEventDispatcherInterface::ENTITY_ACCESS => function (EntityAccessEvent $event) use ($accessResult) {
         $event->addAccessResult($accessResult);
       },
     ]);
@@ -152,7 +152,7 @@ class EntityAccessEventTest extends UnitTestCase {
   public function testEntityAccessEventForbiddenResult() {
     $accessResult = new AccessResultForbidden();
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::ENTITY_ACCESS => function (EntityAccessEvent $event) use ($accessResult) {
+      HookEventDispatcherInterface::ENTITY_ACCESS => function (EntityAccessEvent $event) use ($accessResult) {
         $event->addAccessResult($accessResult);
       },
     ]);
@@ -181,7 +181,7 @@ class EntityAccessEventTest extends UnitTestCase {
       new AccessResultForbidden(),
     ];
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::ENTITY_ACCESS => function (EntityAccessEvent $event) use ($accessResults) {
+      HookEventDispatcherInterface::ENTITY_ACCESS => function (EntityAccessEvent $event) use ($accessResults) {
         foreach ($accessResults as $accessResult) {
           $event->addAccessResult($accessResult);
         }

--- a/tests/src/Unit/Entity/EntityEventTest.php
+++ b/tests/src/Unit/Entity/EntityEventTest.php
@@ -8,7 +8,7 @@ use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\hook_event_dispatcher\Event\Entity\EntityAccessEvent;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Drupal\Tests\hook_event_dispatcher\Unit\HookEventDispatcherManagerSpy;
 use Drupal\Tests\UnitTestCase;
 
@@ -48,7 +48,7 @@ class EntityEventTest extends UnitTestCase {
     hook_event_dispatcher_entity_create($entity);
 
     /* @var \Drupal\hook_event_dispatcher\Event\Entity\EntityCreateEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::ENTITY_CREATE);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::ENTITY_CREATE);
     $this->assertEquals($entity, $event->getEntity());
   }
 
@@ -61,7 +61,7 @@ class EntityEventTest extends UnitTestCase {
     hook_event_dispatcher_entity_delete($entity);
 
     /* @var \Drupal\hook_event_dispatcher\Event\Entity\EntityDeleteEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::ENTITY_DELETE);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::ENTITY_DELETE);
     $this->assertEquals($entity, $event->getEntity());
   }
 
@@ -74,7 +74,7 @@ class EntityEventTest extends UnitTestCase {
     hook_event_dispatcher_entity_insert($entity);
 
     /* @var \Drupal\hook_event_dispatcher\Event\Entity\EntityInsertEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::ENTITY_INSERT);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::ENTITY_INSERT);
     $this->assertEquals($entity, $event->getEntity());
   }
 
@@ -92,7 +92,7 @@ class EntityEventTest extends UnitTestCase {
     hook_event_dispatcher_entity_load($entities, $entityTypeId);
 
     /* @var \Drupal\hook_event_dispatcher\Event\Entity\EntityLoadEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::ENTITY_LOAD);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::ENTITY_LOAD);
     $this->assertEquals($entities, $event->getEntities());
     $this->assertEquals($entityTypeId, $event->getEntityTypeId());
   }
@@ -106,7 +106,7 @@ class EntityEventTest extends UnitTestCase {
     hook_event_dispatcher_entity_predelete($entity);
 
     /* @var \Drupal\hook_event_dispatcher\Event\Entity\EntityPredeleteEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::ENTITY_PRE_DELETE);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::ENTITY_PRE_DELETE);
     $this->assertEquals($entity, $event->getEntity());
   }
 
@@ -121,7 +121,7 @@ class EntityEventTest extends UnitTestCase {
     hook_event_dispatcher_entity_presave($entity);
 
     /* @var \Drupal\hook_event_dispatcher\Event\Entity\EntityPresaveEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::ENTITY_PRE_SAVE);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::ENTITY_PRE_SAVE);
     $this->assertEquals($entity, $event->getEntity());
     $this->assertEquals($originalEntity, $event->getOriginalEntity());
   }
@@ -137,7 +137,7 @@ class EntityEventTest extends UnitTestCase {
     hook_event_dispatcher_entity_update($entity);
 
     /* @var \Drupal\hook_event_dispatcher\Event\Entity\EntityUpdateEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::ENTITY_UPDATE);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::ENTITY_UPDATE);
     $this->assertEquals($entity, $event->getEntity());
     $this->assertEquals($originalEntity, $event->getOriginalEntity());
   }
@@ -154,7 +154,7 @@ class EntityEventTest extends UnitTestCase {
     hook_event_dispatcher_entity_view($build, $entity, $display, $viewMode);
 
     /* @var \Drupal\hook_event_dispatcher\Event\Entity\EntityViewEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::ENTITY_VIEW);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::ENTITY_VIEW);
     $this->assertEquals($build, $event->getBuild());
     $this->assertEquals($entity, $event->getEntity());
     $this->assertEquals($display, $event->getDisplay());

--- a/tests/src/Unit/EntityExtra/EntityExtraEventTest.php
+++ b/tests/src/Unit/EntityExtra/EntityExtraEventTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\hook_event_dispatcher\Unit\EntityExtra;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\hook_event_dispatcher\Event\EntityExtra\EntityExtraFieldInfoAlterEvent;
 use Drupal\hook_event_dispatcher\Event\EntityExtra\EntityExtraFieldInfoEvent;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Drupal\Tests\hook_event_dispatcher\Unit\HookEventDispatcherManagerSpy;
 use Drupal\Tests\UnitTestCase;
 
@@ -41,7 +41,7 @@ class EntityExtraEventTest extends UnitTestCase {
    */
   public function testEntityExtraFieldInfoEventWithHelperFunctions() {
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::ENTITY_EXTRA_FIELD_INFO => function (EntityExtraFieldInfoEvent $event) {
+      HookEventDispatcherInterface::ENTITY_EXTRA_FIELD_INFO => function (EntityExtraFieldInfoEvent $event) {
         $event->addDisplayFieldInfo('node', 'test', 'field_test', ['test' => 'node']);
         $event->addFormFieldInfo('entity', 'test_entity', 'field_node', ['test' => 'entity']);
       },
@@ -71,7 +71,7 @@ class EntityExtraEventTest extends UnitTestCase {
     $this->assertEquals($expectedFieldInfo, $hookFieldInfoResult);
 
     /* @var \Drupal\hook_event_dispatcher\Event\EntityExtra\EntityExtraFieldInfoEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::ENTITY_EXTRA_FIELD_INFO);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::ENTITY_EXTRA_FIELD_INFO);
     $this->assertEquals($expectedFieldInfo, $event->getFieldInfo());
   }
 
@@ -101,7 +101,7 @@ class EntityExtraEventTest extends UnitTestCase {
     ];
 
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::ENTITY_EXTRA_FIELD_INFO => function (EntityExtraFieldInfoEvent $event) use ($fieldInfo) {
+      HookEventDispatcherInterface::ENTITY_EXTRA_FIELD_INFO => function (EntityExtraFieldInfoEvent $event) use ($fieldInfo) {
         $event->setFieldInfo($fieldInfo);
       },
     ]);
@@ -110,7 +110,7 @@ class EntityExtraEventTest extends UnitTestCase {
     $this->assertEquals($fieldInfo, $hookFieldInfoResult);
 
     /* @var \Drupal\hook_event_dispatcher\Event\EntityExtra\EntityExtraFieldInfoEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::ENTITY_EXTRA_FIELD_INFO);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::ENTITY_EXTRA_FIELD_INFO);
     $this->assertEquals($fieldInfo, $event->getFieldInfo());
   }
 
@@ -119,7 +119,7 @@ class EntityExtraEventTest extends UnitTestCase {
    */
   public function testEntityExtraFieldInfoAlterEvent() {
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::ENTITY_EXTRA_FIELD_INFO_ALTER => function (EntityExtraFieldInfoAlterEvent $event) {
+      HookEventDispatcherInterface::ENTITY_EXTRA_FIELD_INFO_ALTER => function (EntityExtraFieldInfoAlterEvent $event) {
         $info = &$event->getFieldInfo();
         $info['taxonomy_term']['sheep']['display']['field_herd']['sheep'] = 'herd';
       },
@@ -150,7 +150,7 @@ class EntityExtraEventTest extends UnitTestCase {
     hook_event_dispatcher_entity_extra_field_info_alter($fieldInfo);
 
     /* @var \Drupal\hook_event_dispatcher\Event\EntityExtra\EntityExtraFieldInfoAlterEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::ENTITY_EXTRA_FIELD_INFO_ALTER);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::ENTITY_EXTRA_FIELD_INFO_ALTER);
     $this->assertEquals($expectedFieldInfo, $event->getFieldInfo());
     $this->assertEquals($expectedFieldInfo, $fieldInfo);
   }

--- a/tests/src/Unit/EntityField/EntityFieldAccessEventTest.php
+++ b/tests/src/Unit/EntityField/EntityFieldAccessEventTest.php
@@ -8,7 +8,7 @@ use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\hook_event_dispatcher\Event\EntityField\EntityFieldAccessEvent;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Drupal\Tests\hook_event_dispatcher\Unit\HookEventDispatcherManagerSpy;
 use Drupal\Tests\UnitTestCase;
 
@@ -45,7 +45,7 @@ class EntityFieldAccessEventTest extends UnitTestCase {
   public function testEntityFieldAccessEvent() {
     $accessResult = $this->createMock(AccessResultInterface::class);
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::ENTITY_FIELD_ACCESS => function (EntityFieldAccessEvent $event) use ($accessResult) {
+      HookEventDispatcherInterface::ENTITY_FIELD_ACCESS => function (EntityFieldAccessEvent $event) use ($accessResult) {
         $event->setAccessResult($accessResult);
       },
     ]);
@@ -58,7 +58,7 @@ class EntityFieldAccessEventTest extends UnitTestCase {
     $hookAccessResult = hook_event_dispatcher_entity_field_access($operation, $fieldDefinition, $account, $items);
 
     /* @var \Drupal\hook_event_dispatcher\Event\EntityField\EntityFieldAccessEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::ENTITY_FIELD_ACCESS);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::ENTITY_FIELD_ACCESS);
     $this->assertEquals($operation, $event->getOperation());
     $this->assertEquals($fieldDefinition, $event->getFieldDefinition());
     $this->assertEquals($account, $event->getAccount());

--- a/tests/src/Unit/EntityType/EntityTypeBaseFieldTest.php
+++ b/tests/src/Unit/EntityType/EntityTypeBaseFieldTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\hook_event_dispatcher\Unit\EntityType;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\hook_event_dispatcher\Event\EntityType\EntityBaseFieldInfoEvent;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Drupal\Tests\hook_event_dispatcher\Unit\HookEventDispatcherManagerSpy;
 use Drupal\Tests\UnitTestCase;
 
@@ -45,7 +45,7 @@ class EntityTypeBaseFieldTest extends UnitTestCase {
       'field_test2' => 'otherTest',
     ];
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::ENTITY_BASE_FIELD_INFO => function (EntityBaseFieldInfoEvent $event) use ($fields) {
+      HookEventDispatcherInterface::ENTITY_BASE_FIELD_INFO => function (EntityBaseFieldInfoEvent $event) use ($fields) {
         $event->setFields($fields);
       },
     ]);
@@ -55,7 +55,7 @@ class EntityTypeBaseFieldTest extends UnitTestCase {
     $hookFieldInfoResult = hook_event_dispatcher_entity_base_field_info($entityType);
 
     /* @var \Drupal\hook_event_dispatcher\Event\EntityType\EntityBaseFieldInfoEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::ENTITY_BASE_FIELD_INFO);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::ENTITY_BASE_FIELD_INFO);
 
     $this->assertEquals($entityType, $event->getEntityType());
     $this->assertEquals($fields, $event->getFields());

--- a/tests/src/Unit/Form/FormEventTest.php
+++ b/tests/src/Unit/Form/FormEventTest.php
@@ -6,7 +6,7 @@ use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Drupal\Tests\hook_event_dispatcher\Unit\HookEventDispatcherManagerSpy;
 use Drupal\Tests\UnitTestCase;
 
@@ -50,7 +50,7 @@ class FormEventTest extends UnitTestCase {
     hook_event_dispatcher_form_alter($form, $formState, $formId);
 
     /* @var \Drupal\hook_event_dispatcher\Event\Form\FormAlterEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::FORM_ALTER);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::FORM_ALTER);
     $this->assertEquals($form, $event->getForm());
     $this->assertEquals($formState, $event->getFormState());
     $this->assertEquals($formId, $event->getFormId());
@@ -123,7 +123,7 @@ class FormEventTest extends UnitTestCase {
     hook_event_dispatcher_field_widget_form_alter($element, $formState, $context);
 
     /* @var \Drupal\hook_event_dispatcher\Event\Form\WidgetFormAlterEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::WIDGET_FORM_ALTER);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::WIDGET_FORM_ALTER);
     $this->assertEquals($element, $event->getElement());
     $this->assertEquals($formState, $event->getFormState());
     $this->assertEquals($context, $event->getContext());

--- a/tests/src/Unit/Path/PathEventTest.php
+++ b/tests/src/Unit/Path/PathEventTest.php
@@ -3,7 +3,7 @@
 namespace Drupal\Tests\hook_event_dispatcher\Unit\Path;
 
 use Drupal\Core\DependencyInjection\ContainerBuilder;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Drupal\Tests\hook_event_dispatcher\Unit\HookEventDispatcherManagerSpy;
 use Drupal\Tests\UnitTestCase;
 
@@ -53,7 +53,7 @@ class PathEventTest extends UnitTestCase {
     hook_event_dispatcher_path_delete($path);
 
     /* @var \Drupal\hook_event_dispatcher\Event\Path\PathDeleteEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::PATH_DELETE);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::PATH_DELETE);
     $this->assertEquals($source, $event->getSource());
     $this->assertEquals($alias, $event->getAlias());
     $this->assertEquals($langcode, $event->getLangcode());
@@ -79,7 +79,7 @@ class PathEventTest extends UnitTestCase {
     hook_event_dispatcher_path_insert($path);
 
     /* @var \Drupal\hook_event_dispatcher\Event\Path\PathInsertEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::PATH_INSERT);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::PATH_INSERT);
     $this->assertEquals($source, $event->getSource());
     $this->assertEquals($alias, $event->getAlias());
     $this->assertEquals($langcode, $event->getLangcode());
@@ -104,7 +104,7 @@ class PathEventTest extends UnitTestCase {
     hook_event_dispatcher_path_update($path);
 
     /* @var \Drupal\hook_event_dispatcher\Event\Path\PathUpdateEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::PATH_UPDATE);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::PATH_UPDATE);
     $this->assertEquals($source, $event->getSource());
     $this->assertEquals($alias, $event->getAlias());
     $this->assertEquals($langcode, $event->getLangcode());

--- a/tests/src/Unit/Theme/JsAlterEventTest.php
+++ b/tests/src/Unit/Theme/JsAlterEventTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\hook_event_dispatcher\Unit\Theme;
 use Drupal\Core\Asset\AttachedAssets;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\hook_event_dispatcher\Event\Theme\JsAlterEvent;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Drupal\Tests\hook_event_dispatcher\Unit\HookEventDispatcherManagerSpy;
 use Drupal\Tests\UnitTestCase;
 
@@ -41,7 +41,7 @@ final class JsAlterEventTest extends UnitTestCase {
    */
   public function testJsAlterEventByReference() {
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::JS_ALTER => function (JsAlterEvent $event) {
+      HookEventDispatcherInterface::JS_ALTER => function (JsAlterEvent $event) {
         $javascript = &$event->getJavascript();
         unset($javascript['unset']);
       },
@@ -58,7 +58,7 @@ final class JsAlterEventTest extends UnitTestCase {
     hook_event_dispatcher_js_alter($javascript, $attachedAssets);
 
     /** @var \Drupal\hook_event_dispatcher\Event\Theme\JsAlterEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::JS_ALTER);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::JS_ALTER);
 
     $this->assertSame($expectedJavascript, $event->getJavascript());
     $this->assertSame($attachedAssets, $event->getAttachedAssets());
@@ -72,7 +72,7 @@ final class JsAlterEventTest extends UnitTestCase {
       'new' => ['new-data'],
     ];
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::JS_ALTER => function (JsAlterEvent $event) use ($newJavascript) {
+      HookEventDispatcherInterface::JS_ALTER => function (JsAlterEvent $event) use ($newJavascript) {
         $javascript = $event->getJavascript();
         $javascript += $newJavascript;
         $event->setJavascript($javascript);
@@ -90,7 +90,7 @@ final class JsAlterEventTest extends UnitTestCase {
     hook_event_dispatcher_js_alter($javascript, $attachedAssets);
 
     /** @var \Drupal\hook_event_dispatcher\Event\Theme\JsAlterEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::JS_ALTER);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::JS_ALTER);
 
     $this->assertSame($expectedJavascript, $event->getJavascript());
     $this->assertSame($attachedAssets, $event->getAttachedAssets());

--- a/tests/src/Unit/Theme/TemplatePreprocessDefaultVariablesAlterEventTest.php
+++ b/tests/src/Unit/Theme/TemplatePreprocessDefaultVariablesAlterEventTest.php
@@ -4,7 +4,7 @@ namespace Drupal\Tests\hook_event_dispatcher\Unit\Theme;
 
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\hook_event_dispatcher\Event\Theme\TemplatePreprocessDefaultVariablesAlterEvent;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Drupal\Tests\hook_event_dispatcher\Unit\HookEventDispatcherManagerSpy;
 use Drupal\Tests\UnitTestCase;
 
@@ -43,7 +43,7 @@ final class TemplatePreprocessDefaultVariablesAlterEventTest extends UnitTestCas
       'test_variable' => TRUE
     ];
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::TEMPLATE_PREPROCESS_DEFAULT_VARIABLES_ALTER => function (TemplatePreprocessDefaultVariablesAlterEvent $event) use ($newVariable) {
+      HookEventDispatcherInterface::TEMPLATE_PREPROCESS_DEFAULT_VARIABLES_ALTER => function (TemplatePreprocessDefaultVariablesAlterEvent $event) use ($newVariable) {
         $variables = &$event->getVariables();
         $variables += $newVariable;
       },
@@ -65,7 +65,7 @@ final class TemplatePreprocessDefaultVariablesAlterEventTest extends UnitTestCas
     hook_event_dispatcher_template_preprocess_default_variables_alter($variables);
 
     /** @var \Drupal\hook_event_dispatcher\Event\Theme\TemplatePreprocessDefaultVariablesAlterEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::TEMPLATE_PREPROCESS_DEFAULT_VARIABLES_ALTER);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::TEMPLATE_PREPROCESS_DEFAULT_VARIABLES_ALTER);
     $this->assertSame($expectedVariables, $event->getVariables());
   }
 
@@ -77,7 +77,7 @@ final class TemplatePreprocessDefaultVariablesAlterEventTest extends UnitTestCas
       'test_variable' => TRUE
     ];
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::TEMPLATE_PREPROCESS_DEFAULT_VARIABLES_ALTER => function (TemplatePreprocessDefaultVariablesAlterEvent $event) use ($newVariable) {
+      HookEventDispatcherInterface::TEMPLATE_PREPROCESS_DEFAULT_VARIABLES_ALTER => function (TemplatePreprocessDefaultVariablesAlterEvent $event) use ($newVariable) {
         $variables = $event->getVariables();
         $variables += $newVariable;
         $event->setVariables($variables);
@@ -100,7 +100,7 @@ final class TemplatePreprocessDefaultVariablesAlterEventTest extends UnitTestCas
     hook_event_dispatcher_template_preprocess_default_variables_alter($variables);
 
     /** @var \Drupal\hook_event_dispatcher\Event\Theme\TemplatePreprocessDefaultVariablesAlterEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::TEMPLATE_PREPROCESS_DEFAULT_VARIABLES_ALTER);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::TEMPLATE_PREPROCESS_DEFAULT_VARIABLES_ALTER);
     $this->assertSame($expectedVariables, $event->getVariables());
   }
 

--- a/tests/src/Unit/Theme/ThemeEventTest.php
+++ b/tests/src/Unit/Theme/ThemeEventTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\hook_event_dispatcher\Unit\Theme;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\hook_event_dispatcher\Event\Theme\ThemeEvent;
 use Drupal\Tests\hook_event_dispatcher\Unit\HookEventDispatcherManagerSpy;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Drupal\Tests\UnitTestCase;
 
 /**
@@ -48,7 +48,7 @@ class ThemeEventTest extends UnitTestCase {
       ],
     ];
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::THEME => function (ThemeEvent $event) use ($newThemes) {
+      HookEventDispatcherInterface::THEME => function (ThemeEvent $event) use ($newThemes) {
         $event->addNewThemes($newThemes);
       },
     ]);
@@ -70,7 +70,7 @@ class ThemeEventTest extends UnitTestCase {
     $hookNewInformation = hook_event_dispatcher_theme($existing);
 
     /** @var \Drupal\hook_event_dispatcher\Event\Theme\ThemeEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::THEME);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::THEME);
     $this->assertSame($existing, $event->getExisting());
     $this->assertSame($newThemes, $hookNewInformation);
   }
@@ -87,7 +87,7 @@ class ThemeEventTest extends UnitTestCase {
       ],
     ];
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::THEME => function (ThemeEvent $event) use ($newThemes) {
+      HookEventDispatcherInterface::THEME => function (ThemeEvent $event) use ($newThemes) {
         $event->addNewThemes($newThemes);
       },
     ]);
@@ -110,7 +110,7 @@ class ThemeEventTest extends UnitTestCase {
     $expectedNewTheme[$themeHook] = $information;
 
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::THEME => function (ThemeEvent $event) use ($themeHook, $information) {
+      HookEventDispatcherInterface::THEME => function (ThemeEvent $event) use ($themeHook, $information) {
         $event->addNewTheme($themeHook, $information);
       },
     ]);
@@ -132,7 +132,7 @@ class ThemeEventTest extends UnitTestCase {
     $hookNewInformation = hook_event_dispatcher_theme($existing);
 
     /** @var \Drupal\hook_event_dispatcher\Event\Theme\ThemeEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::THEME);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::THEME);
     $this->assertSame($existing, $event->getExisting());
     $this->assertSame($expectedNewTheme, $hookNewInformation);
   }
@@ -147,7 +147,7 @@ class ThemeEventTest extends UnitTestCase {
     ];
 
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::THEME => function (ThemeEvent $event) use ($themeHook, $information) {
+      HookEventDispatcherInterface::THEME => function (ThemeEvent $event) use ($themeHook, $information) {
         $event->addNewTheme($themeHook, $information);
       },
     ]);

--- a/tests/src/Unit/Theme/ThemeSuggestionsAlterEventTest.php
+++ b/tests/src/Unit/Theme/ThemeSuggestionsAlterEventTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\hook_event_dispatcher\Unit\Theme;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\hook_event_dispatcher\Event\Theme\ThemeSuggestionsAlterEvent;
 use Drupal\Tests\hook_event_dispatcher\Unit\HookEventDispatcherManagerSpy;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Drupal\Tests\UnitTestCase;
 
 /**
@@ -51,7 +51,7 @@ class ThemeSuggestionsAlterEventTest extends UnitTestCase {
     hook_event_dispatcher_theme_suggestions_alter($suggestions, $variables, $hook);
 
     /** @var \Drupal\hook_event_dispatcher\Event\Theme\ThemeSuggestionsAlterEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::THEME_SUGGESTIONS_ALTER);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::THEME_SUGGESTIONS_ALTER);
     $this->assertEquals($suggestions, $event->getSuggestions());
     $this->assertEquals($variables, $event->getVariables());
   }
@@ -75,7 +75,7 @@ class ThemeSuggestionsAlterEventTest extends UnitTestCase {
     ];
 
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::THEME_SUGGESTIONS_ALTER => function (ThemeSuggestionsAlterEvent $event) use ($newSuggestions) {
+      HookEventDispatcherInterface::THEME_SUGGESTIONS_ALTER => function (ThemeSuggestionsAlterEvent $event) use ($newSuggestions) {
         $event->setSuggestions($newSuggestions);
       },
     ]);
@@ -83,7 +83,7 @@ class ThemeSuggestionsAlterEventTest extends UnitTestCase {
     hook_event_dispatcher_theme_suggestions_alter($suggestions, $variables, $hook);
 
     /** @var \Drupal\hook_event_dispatcher\Event\Theme\ThemeSuggestionsAlterEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::THEME_SUGGESTIONS_ALTER);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::THEME_SUGGESTIONS_ALTER);
     $this->assertEquals($newSuggestions, $event->getSuggestions());
     $this->assertEquals($variables, $event->getVariables());
   }

--- a/tests/src/Unit/Token/TokenEventTest.php
+++ b/tests/src/Unit/Token/TokenEventTest.php
@@ -6,7 +6,7 @@ use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\hook_event_dispatcher\Event\Token\TokensInfoEvent;
 use Drupal\hook_event_dispatcher\Event\Token\TokensReplacementEvent;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Drupal\hook_event_dispatcher\Value\Token;
 use Drupal\hook_event_dispatcher\Value\TokenType;
 use Drupal\Tests\hook_event_dispatcher\Unit\HookEventDispatcherManagerSpy;
@@ -54,7 +54,7 @@ class TokenEventTest extends UnitTestCase {
     ];
 
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::TOKEN_INFO => function (TokensInfoEvent $event) use ($types, $tokens) {
+      HookEventDispatcherInterface::TOKEN_INFO => function (TokensInfoEvent $event) use ($types, $tokens) {
         foreach ($types as $type) {
           $event->addTokenType($type);
         }
@@ -97,7 +97,7 @@ class TokenEventTest extends UnitTestCase {
       ],
     ];
     /* @var \Drupal\hook_event_dispatcher\Event\Token\TokensInfoEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::TOKEN_INFO);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::TOKEN_INFO);
     $this->assertEquals($expectedTypes, $result['types']);
     $this->assertEquals($expectedTokens, $result['tokens']);
     $this->assertEquals($expectedTypes, $event->getTokenTypes());
@@ -112,7 +112,7 @@ class TokenEventTest extends UnitTestCase {
     $replacement2 = 'Replacement value 2';
 
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::TOKEN_REPLACEMENT => function (TokensReplacementEvent $event) use ($replacement1, $replacement2) {
+      HookEventDispatcherInterface::TOKEN_REPLACEMENT => function (TokensReplacementEvent $event) use ($replacement1, $replacement2) {
         $event->setReplacementValue('test_type', 'token1', $replacement1);
         $event->setReplacementValue('test_type', 'token2', $replacement2);
       },
@@ -139,7 +139,7 @@ class TokenEventTest extends UnitTestCase {
       '[test_type:token2]' => $replacement2,
     ];
     /* @var \Drupal\hook_event_dispatcher\Event\Token\TokensReplacementEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::TOKEN_REPLACEMENT);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::TOKEN_REPLACEMENT);
     $this->assertEquals($expectedResult, $result);
     $this->assertEquals($type, $event->getType());
     $this->assertEquals($tokens, $event->getTokens());

--- a/tests/src/Unit/Toolbar/ToolbarAlterEventTest.php
+++ b/tests/src/Unit/Toolbar/ToolbarAlterEventTest.php
@@ -3,7 +3,7 @@
 namespace Drupal\Tests\hook_event_dispatcher\Unit\Toolbar;
 
 use Drupal\hook_event_dispatcher\Event\Toolbar\ToolbarAlterEvent;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Drupal\Tests\hook_event_dispatcher\Unit\HookEventDispatcherManagerSpy;
 use Drupal\Tests\UnitTestCase;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
@@ -42,7 +42,7 @@ class ToolbarAlterEventTest extends UnitTestCase {
     $newItem = ['test' => 'item'];
 
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::TOOLBAR_ALTER => function (ToolbarAlterEvent $event) use ($newItem) {
+      HookEventDispatcherInterface::TOOLBAR_ALTER => function (ToolbarAlterEvent $event) use ($newItem) {
         $items = &$event->getItems();
         $items += $newItem;
       },
@@ -67,7 +67,7 @@ class ToolbarAlterEventTest extends UnitTestCase {
     $newItem = ['test' => 'item'];
 
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::TOOLBAR_ALTER => function (ToolbarAlterEvent $event) use ($newItem) {
+      HookEventDispatcherInterface::TOOLBAR_ALTER => function (ToolbarAlterEvent $event) use ($newItem) {
         $items = $event->getItems();
         $items += $newItem;
         $event->setItems($items);

--- a/tests/src/Unit/User/UserEventTest.php
+++ b/tests/src/Unit/User/UserEventTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\hook_event_dispatcher\Unit\User;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\hook_event_dispatcher\Event\User\UserFormatNameAlterEvent;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Drupal\Tests\hook_event_dispatcher\Unit\HookEventDispatcherManagerSpy;
 use Drupal\Tests\UnitTestCase;
 
@@ -46,7 +46,7 @@ class UserEventTest extends UnitTestCase {
     hook_event_dispatcher_user_login($account);
 
     /* @var \Drupal\hook_event_dispatcher\Event\User\UserLoginEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::USER_LOGIN);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::USER_LOGIN);
     $this->assertEquals($account, $event->getAccount());
   }
 
@@ -60,7 +60,7 @@ class UserEventTest extends UnitTestCase {
     hook_event_dispatcher_user_logout($account);
 
     /* @var \Drupal\hook_event_dispatcher\Event\User\UserLogoutEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::USER_LOGOUT);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::USER_LOGOUT);
     $this->assertEquals($account, $event->getAccount());
   }
 
@@ -69,7 +69,7 @@ class UserEventTest extends UnitTestCase {
    */
   public function testUserFormatNameAlterEventByReference() {
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::USER_FORMAT_NAME_ALTER => function (UserFormatNameAlterEvent $event) {
+      HookEventDispatcherInterface::USER_FORMAT_NAME_ALTER => function (UserFormatNameAlterEvent $event) {
         $name = &$event->getName();
         $name .= ' improved!';
       },
@@ -82,7 +82,7 @@ class UserEventTest extends UnitTestCase {
     hook_event_dispatcher_user_format_name_alter($name, $account);
 
     /* @var \Drupal\hook_event_dispatcher\Event\User\UserFormatNameAlterEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::USER_FORMAT_NAME_ALTER);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::USER_FORMAT_NAME_ALTER);
     $this->assertSame('Test name improved!', $event->getName());
     $this->assertSame($account, $event->getAccount());
   }
@@ -92,7 +92,7 @@ class UserEventTest extends UnitTestCase {
    */
   public function testUserFormatNameAlterEventWithSet() {
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::USER_FORMAT_NAME_ALTER => function (UserFormatNameAlterEvent $event) {
+      HookEventDispatcherInterface::USER_FORMAT_NAME_ALTER => function (UserFormatNameAlterEvent $event) {
         $event->setName('New name!');
       },
     ]);
@@ -104,7 +104,7 @@ class UserEventTest extends UnitTestCase {
     hook_event_dispatcher_user_format_name_alter($name, $account);
 
     /* @var \Drupal\hook_event_dispatcher\Event\User\UserFormatNameAlterEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::USER_FORMAT_NAME_ALTER);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::USER_FORMAT_NAME_ALTER);
     $this->assertSame('New name!', $event->getName());
     $this->assertSame($account, $event->getAccount());
   }

--- a/tests/src/Unit/Views/ViewEventTest.php
+++ b/tests/src/Unit/Views/ViewEventTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\hook_event_dispatcher\Unit\Views;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\hook_event_dispatcher\Event\Views\ViewsDataAlterEvent;
 use Drupal\hook_event_dispatcher\Event\Views\ViewsDataEvent;
-use Drupal\hook_event_dispatcher\HookEventDispatcherEvents;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Drupal\Tests\hook_event_dispatcher\Unit\HookEventDispatcherManagerSpy;
 use Drupal\views\ViewExecutable;
 use Drupal\Tests\UnitTestCase;
@@ -48,7 +48,7 @@ class ViewEventTest extends UnitTestCase {
     ];
 
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::VIEWS_DATA => function (ViewsDataEvent $event) use ($data) {
+      HookEventDispatcherInterface::VIEWS_DATA => function (ViewsDataEvent $event) use ($data) {
         $event->addData($data);
       },
     ]);
@@ -81,7 +81,7 @@ class ViewEventTest extends UnitTestCase {
     ];
 
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::VIEWS_DATA => function (ViewsDataEvent $event) use ($data1, $data2, $data3) {
+      HookEventDispatcherInterface::VIEWS_DATA => function (ViewsDataEvent $event) use ($data1, $data2, $data3) {
         $event->addData($data1);
         $event->addData($data2);
         $event->addData($data3);
@@ -107,7 +107,7 @@ class ViewEventTest extends UnitTestCase {
    */
   public function testViewsDataAlterEventByReference() {
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::VIEWS_DATA_ALTER => function (ViewsDataAlterEvent $event) {
+      HookEventDispatcherInterface::VIEWS_DATA_ALTER => function (ViewsDataAlterEvent $event) {
         $data = &$event->getData();
         $data['test']['other_test'] = ['some_data'];
       },
@@ -129,7 +129,7 @@ class ViewEventTest extends UnitTestCase {
    */
   public function testViewsDataAlterEventBySet() {
     $this->manager->setEventCallbacks([
-      HookEventDispatcherEvents::VIEWS_DATA_ALTER => function (ViewsDataAlterEvent $event) {
+      HookEventDispatcherInterface::VIEWS_DATA_ALTER => function (ViewsDataAlterEvent $event) {
         $data = $event->getData();
         $data['other'] = ['other_data'];
         $event->setData($data);
@@ -157,7 +157,7 @@ class ViewEventTest extends UnitTestCase {
     hook_event_dispatcher_views_pre_build($view);
 
     /* @var \Drupal\hook_event_dispatcher\Event\Views\ViewsPreBuildEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::VIEWS_PRE_BUILD);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::VIEWS_PRE_BUILD);
     $this->assertEquals($view, $event->getView());
   }
 
@@ -171,7 +171,7 @@ class ViewEventTest extends UnitTestCase {
     hook_event_dispatcher_views_post_build($view);
 
     /* @var \Drupal\hook_event_dispatcher\Event\Views\ViewsPreBuildEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::VIEWS_POST_BUILD);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::VIEWS_POST_BUILD);
     $this->assertEquals($view, $event->getView());
   }
 
@@ -185,7 +185,7 @@ class ViewEventTest extends UnitTestCase {
     hook_event_dispatcher_views_pre_execute($view);
 
     /* @var \Drupal\hook_event_dispatcher\Event\Views\ViewsPreBuildEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::VIEWS_PRE_EXECUTE);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::VIEWS_PRE_EXECUTE);
     $this->assertEquals($view, $event->getView());
   }
 
@@ -199,7 +199,7 @@ class ViewEventTest extends UnitTestCase {
     hook_event_dispatcher_views_post_execute($view);
 
     /* @var \Drupal\hook_event_dispatcher\Event\Views\ViewsPreBuildEvent $event */
-    $event = $this->manager->getRegisteredEvent(HookEventDispatcherEvents::VIEWS_POST_EXECUTE);
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::VIEWS_POST_EXECUTE);
     $this->assertEquals($view, $event->getView());
   }
 


### PR DESCRIPTION
Move all the event constants to an interface, as a class is not needed.
Deprecated the class as this should stay for backwards compatibility.