### PR TITLE
Fix phpunit order

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "jakub-onderka/php-console-highlighter": "^0.3.2",
     "jakub-onderka/php-parallel-lint": "^0.9.2",
     "phpmd/phpmd": "^2.6",
-    "phpunit/phpunit": "^5.7 || ^4"
+    "phpunit/phpunit": "^4 || ^5.7"
   },
   "minimum-stability": "alpha",
   "scripts": {


### PR DESCRIPTION
Generally, the lowest version is put first and then increments are added.