### PR TITLE
Support Webform hooks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,14 @@
   },
   "autoload": {
     "psr-4": {
-      "Drupal\\hook_event_dispatcher\\": "src/"
+      "Drupal\\hook_event_dispatcher\\": "src/",
+      "Drupal\\webform_event_dispatcher\\": "modules/webform_event_dispatcher/src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
       "Drupal\\Tests\\hook_event_dispatcher\\": "tests/src/",
+      "Drupal\\Tests\\webform_event_dispatcher\\": "modules/webform_event_dispatcher/tests/src/",
       "Drupal\\Tests\\": "vendor/drupal/core/tests/Drupal/Tests",
       "Drupal\\views\\": "vendor/drupal/core/modules/views/src/"
     }

--- a/modules/webform_event_dispatcher/src/Event/WebformElement/WebformElementAlterEvent.php
+++ b/modules/webform_event_dispatcher/src/Event/WebformElement/WebformElementAlterEvent.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Drupal\webform_event_dispatcher\Event\WebformElement;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\hook_event_dispatcher\Event\EventInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class WebformElementAlterEvent.
+ *
+ * @package Drupal\webform_event_dispatcher\Event\Element
+ */
+class WebformElementAlterEvent extends Event implements EventInterface {
+
+  /**
+   * The webform element.
+   *
+   * @var array
+   */
+  private $element;
+
+  /**
+   * The form state.
+   *
+   * @var \Drupal\Core\Form\FormStateInterface
+   */
+  private $formState;
+
+  /**
+   * The context.
+   *
+   * @var array
+   */
+  private $context;
+
+  /**
+   * WebformElementAlterEvent constructor.
+   *
+   * @param array $element
+   *   The webform element.
+   * @param \Drupal\Core\Form\FormStateInterface $formState
+   *   The current state of the form.
+   * @param array $context
+   *   An associative array containing the following key-value pairs:
+   *   - form: The form structure to which elements is being attached.
+   */
+  public function __construct(array &$element, FormStateInterface $formState, array $context) {
+    $this->element = &$element;
+    $this->formState = $formState;
+    $this->context = $context;
+  }
+
+  /**
+   * Get the webform element.
+   *
+   * @return array
+   *   The element.
+   */
+  public function &getElement() {
+    return $this->element;
+  }
+
+  /**
+   * Get the webform element type.
+   *
+   * @return string
+   *   The webform element type.
+   */
+  public function getElementType() {
+    return $this->getElement()['#type'];
+  }
+
+  /**
+   * Get the form state.
+   *
+   * @return \Drupal\Core\Form\FormStateInterface
+   *   The form state.
+   */
+  public function getFormState() {
+    return $this->formState;
+  }
+
+  /**
+   * Get the context.
+   *
+   * @return array
+   *   The context.
+   */
+  public function getContext() {
+    return $this->context;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDispatcherType() {
+    return 'hook_event_dispatcher.webform.element.alter';
+  }
+
+}

--- a/modules/webform_event_dispatcher/src/Event/WebformElement/WebformElementInfoAlterEvent.php
+++ b/modules/webform_event_dispatcher/src/Event/WebformElement/WebformElementInfoAlterEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\webform_event_dispatcher\Event\WebformElement;
+
+use Drupal\hook_event_dispatcher\Event\EventInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class WebformElementInfoAlterEvent.
+ *
+ * @package Drupal\webform_event_dispatcher\Event\Element
+ */
+class WebformElementInfoAlterEvent extends Event implements EventInterface {
+
+  /**
+   * The webform element.
+   *
+   * @var array
+   *   The array of webform handlers, keyed on the machine-readable element name.
+   */
+  private $definitions;
+
+  /**
+   * WidgetFormAlterEvent constructor.
+   *
+   * @param array $definitions
+   *   The array of webform handlers, keyed on the machine-readable element name.
+   */
+  public function __construct(array &$definitions) {
+    $this->definitions = &$definitions;
+  }
+
+  /**
+   * Get the definitions.
+   *
+   * @return array
+   *   The array of webform handlers, keyed on the machine-readable element name.
+   */
+  public function &getDefinitions() {
+    return $this->definitions;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDispatcherType() {
+    return 'hook_event_dispatcher.webform.element.info.alter';
+  }
+
+}

--- a/modules/webform_event_dispatcher/src/Event/WebformElement/WebformElementTypeAlterEvent.php
+++ b/modules/webform_event_dispatcher/src/Event/WebformElement/WebformElementTypeAlterEvent.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Drupal\webform_event_dispatcher\Event\WebformElement;
+
+/**
+ * Class WebformElementTypeAlterEvent.
+ *
+ * @package Drupal\webform_event_dispatcher\Event\Element
+ */
+class WebformElementTypeAlterEvent extends WebformElementAlterEvent {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDispatcherType() {
+    $type = $this->getElementType();
+    return 'hook_event_dispatcher.webform.element_' . $type . '.alter';
+  }
+
+}

--- a/modules/webform_event_dispatcher/tests/src/Unit/WebformElement/WebformElementEventTest.php
+++ b/modules/webform_event_dispatcher/tests/src/Unit/WebformElement/WebformElementEventTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Drupal\Tests\webform_event_dispatcher\Unit\WebformElement;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Tests\hook_event_dispatcher\Unit\HookEventDispatcherManagerSpy;
+use Drupal\Tests\UnitTestCase;
+use Drupal\webform_event_dispatcher\Event\WebformElement\WebformElementAlterEvent;
+use Drupal\webform_event_dispatcher\Event\WebformElement\WebformElementInfoAlterEvent;
+use Drupal\webform_event_dispatcher\Event\WebformElement\WebformElementTypeAlterEvent;
+
+/**
+ * Class WebformElementEventTest.
+ *
+ * @package Drupal\Tests\webform_event_dispatcher\Unit\Element
+ *
+ * @group hook_event_dispatcher
+ */
+class WebformFormElementEventTest extends UnitTestCase {
+
+  /**
+   * The manager.
+   *
+   * @var \Drupal\Tests\hook_event_dispatcher\Unit\HookEventDispatcherManagerSpy
+   */
+  private $manager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    $builder = new ContainerBuilder();
+    $this->manager = new HookEventDispatcherManagerSpy();
+    $this->manager->setMaxEventCount(2);
+    $builder->set('hook_event_dispatcher.manager', $this->manager);
+    $builder->compile();
+    \Drupal::setContainer($builder);
+  }
+
+  /**
+   * Test WebformElementInfoAlterEvent.
+   */
+  public function testWebformElementInfoAlterEvent() {
+    $definitions = ['textfield' => ['id' => 'textfield']];
+    $alters = ['textfield' => ['#test' => 'test']];
+    $expectedDefinitions = array_merge_recursive($definitions, $alters);
+
+    // Create event subscriber to alter element info.
+    $this->manager->setEventCallbacks([
+      'hook_event_dispatcher.webform.element.info.alter' => function (WebformElementInfoAlterEvent $event) {
+        $definitions = &$event->getDefinitions();
+        $definitions['textfield']['#test'] = 'test';
+      },
+    ]);
+
+    webform_event_dispatcher_webform_element_info_alter($definitions);
+
+    /* @var \Drupal\webform_event_dispatcher\Event\WebformElement\WebformElementInfoAlterEvent $event */
+    $event = $this->manager->getRegisteredEvent('hook_event_dispatcher.webform.element.info.alter');
+    $this->assertInstanceOf(WebformElementInfoAlterEvent::class, $event);
+    $this->assertSame($expectedDefinitions, $event->getDefinitions());
+  }
+
+  /**
+   * Test WebformElementAlterEvent.
+   */
+  public function testWebformElementAlterEvent() {
+    $element = ['#type' => 'textfield'];
+    $alters = ['#test' => 'test'];
+    $expectedElement = array_merge($element, $alters);
+    $formState = $this->createMock(FormStateInterface::class);
+    $context = ['form' => ['#webform_id' => 'test_form']];
+
+    // Create event subscriber to alter element.
+    $this->manager->setEventCallbacks([
+      'hook_event_dispatcher.webform.element.alter' => function (WebformElementAlterEvent $event) {
+        $element = &$event->getElement();
+        $element['#test'] = 'test';
+      },
+    ]);
+
+    webform_event_dispatcher_webform_element_alter($element, $formState, $context);
+
+    /* @var \Drupal\webform_event_dispatcher\Event\WebformElement\WebformElementAlterEvent $event */
+    $event = $this->manager->getRegisteredEvent('hook_event_dispatcher.webform.element.alter');
+    $this->assertInstanceOf(WebformElementAlterEvent::class, $event);
+    $this->assertSame($expectedElement, $event->getElement());
+    $this->assertSame($formState, $event->getFormState());
+    $this->assertSame($context, $event->getContext());
+  }
+
+  /**
+   * Test WebformElementTypeAlterEvent.
+   */
+  public function testWebformElementTypeAlterEvent() {
+    $elementType = 'textfield';
+    $element = ['#type' => $elementType];
+    $alters = ['#test' => 'test'];
+    $expectedElement = array_merge($element, $alters);
+    $formState = $this->createMock(FormStateInterface::class);
+    $context = ['form' => ['#webform_id' => 'test_form']];
+
+    // Create event subscriber to alter element of given type.
+    $this->manager->setEventCallbacks([
+      "hook_event_dispatcher.webform.element_$elementType.alter" => function (WebformElementAlterEvent $event) {
+        $element = &$event->getElement();
+        $element['#test'] = 'test';
+      },
+    ]);
+
+    webform_event_dispatcher_webform_element_alter($element, $formState, $context);
+
+    /* @var \Drupal\webform_event_dispatcher\Event\WebformElement\WebformElementTypeAlterEvent $event */
+    $event = $this->manager->getRegisteredEvent("hook_event_dispatcher.webform.element_$elementType.alter");
+    $this->assertInstanceOf(WebformElementTypeAlterEvent::class, $event);
+    $this->assertSame($expectedElement, $event->getElement());
+    $this->assertSame($elementType, $event->getElementType());
+    $this->assertSame($formState, $event->getFormState());
+    $this->assertSame($context, $event->getContext());
+  }
+
+}

--- a/modules/webform_event_dispatcher/webform_event_dispatcher.info.yml
+++ b/modules/webform_event_dispatcher/webform_event_dispatcher.info.yml
@@ -1,0 +1,8 @@
+name: Webform Event Dispatcher
+type: module
+description: Registers event dispatchers for several webform hooks
+core: 8.x
+package: Development
+dependencies:
+  - hook_event_dispatcher:hook_event_dispatcher
+  - webform:webform

--- a/modules/webform_event_dispatcher/webform_event_dispatcher.module
+++ b/modules/webform_event_dispatcher/webform_event_dispatcher.module
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @file
+ * Webform event dispatcher submodule.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\webform_event_dispatcher\Event\WebformElement\WebformElementInfoAlterEvent;
+use Drupal\webform_event_dispatcher\Event\WebformElement\WebformElementAlterEvent;
+use Drupal\webform_event_dispatcher\Event\WebformElement\WebformElementTypeAlterEvent;
+
+// @todo add support for hook_webform_handler_info_alter
+// @todo add support for hook_webform_source_entity_info_alter
+// @todo add support for hook_webform_options_alter
+// @todo add support for hook_webform_options_WEBFORM_OPTIONS_ID_alter
+// @todo add support for hook_webform_submission_form_alter
+// @todo add support for hook_webform_admin_third_party_settings_form_alter
+// @todo add support for hook_webform_third_party_settings_form_alter
+// @todo add support for hook_webform_handler_invoke_alter
+// @todo add support for hook_webform_handler_invoke_METHOD_NAME_alter
+// @todo add support for hook_webform_libraries_info
+// @todo add support for hook_webform_libraries_info_alter
+// @todo add support for hook_webform_access_rules
+// @todo add support for hook_webform_access_rules_alter
+// @todo add support for hook_webform_submission_access
+// @todo add support for hook_webform_message_custom
+
+/**
+ * Implements hook_webform_element_info_alter().
+ */
+function webform_event_dispatcher_webform_element_info_alter(array &$definitions) {
+  /* @var \Drupal\hook_event_dispatcher\Manager\HookEventDispatcherManagerInterface $manager */
+  $manager = \Drupal::service('hook_event_dispatcher.manager');
+  $manager->register(new WebformElementInfoAlterEvent($definitions));
+}
+
+/**
+ * Implements hook_webform_element_alter().
+ */
+function webform_event_dispatcher_webform_element_alter(array &$element, FormStateInterface $formState, array $context) {
+  /* @var \Drupal\hook_event_dispatcher\Manager\HookEventDispatcherManagerInterface $manager */
+  $manager = \Drupal::service('hook_event_dispatcher.manager');
+  $manager->register(new WebformElementAlterEvent($element, $formState, $context));
+  $manager->register(new WebformElementTypeAlterEvent($element, $formState, $context));
+}

--- a/phpunit.autoload.php
+++ b/phpunit.autoload.php
@@ -7,3 +7,4 @@
 
 require 'vendor/autoload.php';
 require 'hook_event_dispatcher.module';
+require 'modules/webform_event_dispatcher/webform_event_dispatcher.module';

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,6 +12,7 @@
     <testsuites>
         <testsuite name="Test Suite">
             <directory>tests/src/</directory>
+            <directory>modules/*/tests/src</directory>
         </testsuite>
     </testsuites>
     <filter>


### PR DESCRIPTION
Per our discussion on [d.o](https://www.drupal.org/project/hook_event_dispatcher/issues/3028460), here is an initial patch which adds events for a number of webform element hooks:

- [ ] `hook_webform_element_info_alter(&$definitions)`
- [ ] `hook_webform_element_alter(&$element, $form_state, $context)`
- [ ] `hook_webform_element_ELEMENT_TYPE_alter(&$element, $form_state, $context)`

Added tests for the aforementioned three hooks, and `@todo`'s for the remaining webform hooks.