### PR TITLE
Remove composer install memory limit on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
   - ~/.composer
 
 install:
-- composer install
+- COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-dist
 
 script:
 - vendor/bin/parallel-lint --exclude vendor/ -e php,module,inc,install,profile,theme .


### PR DESCRIPTION
https://lorenzo.mile.si/travis-ci-and-composer-out-of-memory/739/