### PR TITLE
Added entity translation hooks

### DIFF
--- a/hook_event_dispatcher.module
+++ b/hook_event_dispatcher.module
@@ -24,6 +24,8 @@ use Drupal\hook_event_dispatcher\Event\Entity\EntityInsertEvent;
 use Drupal\hook_event_dispatcher\Event\Entity\EntityLoadEvent;
 use Drupal\hook_event_dispatcher\Event\Entity\EntityPredeleteEvent;
 use Drupal\hook_event_dispatcher\Event\Entity\EntityPresaveEvent;
+use Drupal\hook_event_dispatcher\Event\Entity\EntityTranslationDeleteEvent;
+use Drupal\hook_event_dispatcher\Event\Entity\EntityTranslationInsertEvent;
 use Drupal\hook_event_dispatcher\Event\Entity\EntityUpdateEvent;
 use Drupal\hook_event_dispatcher\Event\Entity\EntityViewEvent;
 use Drupal\hook_event_dispatcher\Event\EntityExtra\EntityExtraFieldInfoAlterEvent;
@@ -169,6 +171,28 @@ function hook_event_dispatcher_entity_load(array $entities, $entityTypeId) {
   /* @var \Drupal\hook_event_dispatcher\Manager\HookEventDispatcherManagerInterface $manager */
   $manager = \Drupal::service('hook_event_dispatcher.manager');
   $manager->register(new EntityLoadEvent($entities, $entityTypeId));
+}
+
+/**
+ * Implements hook_entity_translation_insert().
+ *
+ * {@inheritdoc}
+ */
+function hook_event_dispatcher_entity_translation_insert(EntityInterface $translation) {
+  /* @var \Drupal\hook_event_dispatcher\Manager\HookEventDispatcherManagerInterface $manager */
+  $manager = \Drupal::service('hook_event_dispatcher.manager');
+  $manager->register(new EntityTranslationInsertEvent($translation));
+}
+
+/**
+ * Implements hook_entity_translation_delete().
+ *
+ * {@inheritdoc}
+ */
+function hook_event_dispatcher_entity_translation_delete(EntityInterface $translation) {
+  /* @var \Drupal\hook_event_dispatcher\Manager\HookEventDispatcherManagerInterface $manager */
+  $manager = \Drupal::service('hook_event_dispatcher.manager');
+  $manager->register(new EntityTranslationDeleteEvent($translation));
 }
 
 /**

--- a/src/Event/Entity/EntityTranslationDeleteEvent.php
+++ b/src/Event/Entity/EntityTranslationDeleteEvent.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\hook_event_dispatcher\Event\Entity;
+
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
+
+/**
+ * Class EntityTranslationDeleteEvent.
+ */
+class EntityTranslationDeleteEvent extends BaseEntityEvent {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDispatcherType() {
+    return HookEventDispatcherInterface::ENTITY_TRANSLATION_DELETE;
+  }
+
+}

--- a/src/Event/Entity/EntityTranslationInsertEvent.php
+++ b/src/Event/Entity/EntityTranslationInsertEvent.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\hook_event_dispatcher\Event\Entity;
+
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
+
+/**
+ * Class EntityTranslationInsertEvent.
+ */
+class EntityTranslationInsertEvent extends BaseEntityEvent {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDispatcherType() {
+    return HookEventDispatcherInterface::ENTITY_TRANSLATION_INSERT;
+  }
+
+}

--- a/src/HookEventDispatcherInterface.php
+++ b/src/HookEventDispatcherInterface.php
@@ -116,6 +116,30 @@ interface HookEventDispatcherInterface {
    */
   const ENTITY_LOAD = 'hook_event_dispatcher.entity.load';
 
+  /**
+   * Respond to creation of a new entity translation.
+   *
+   * @Event
+   *
+   * @see hook_event_dispatcher_entity_translation_insert()
+   * @see hook_entity_translation_insert()
+   *
+   * @var string
+   */
+  const ENTITY_TRANSLATION_INSERT = 'hook_event_dispatcher.entity.translation_insert';
+
+  /**
+   * Respond to deletion of a new entity translation.
+   *
+   * @Event
+   *
+   * @see hook_event_dispatcher_entity_translation_delete()
+   * @see hook_entity_translation_delete()
+   *
+   * @var string
+   */
+  const ENTITY_TRANSLATION_DELETE = 'hook_event_dispatcher.entity.translation_delete';
+
   // ENTITY FIELD EVENTS.
   /**
    * Control access to fields.

--- a/tests/src/Unit/Entity/EntityEventTest.php
+++ b/tests/src/Unit/Entity/EntityEventTest.php
@@ -98,6 +98,32 @@ class EntityEventTest extends UnitTestCase {
   }
 
   /**
+   * Test EntityTranslationInsertEvent.
+   */
+  public function testEntityTranslationInsertEvent() {
+    $entity = $this->createMock(EntityInterface::class);
+
+    hook_event_dispatcher_entity_translation_insert($entity);
+
+    /* @var \Drupal\hook_event_dispatcher\Event\Entity\EntityTranslationInsertEvent $event */
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::ENTITY_TRANSLATION_INSERT);
+    $this->assertEquals($entity, $event->getEntity());
+  }
+
+  /**
+   * Test EntityTranslationDeleteEvent.
+   */
+  public function testEntityTranslationDeleteEvent() {
+    $entity = $this->createMock(EntityInterface::class);
+
+    hook_event_dispatcher_entity_translation_delete($entity);
+
+    /* @var \Drupal\hook_event_dispatcher\Event\Entity\EntityTranslationDeleteEvent $event */
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::ENTITY_TRANSLATION_DELETE);
+    $this->assertEquals($entity, $event->getEntity());
+  }
+
+  /**
    * Test EntityPredeleteEvent.
    */
   public function testEntityPredeleteEvent() {


### PR DESCRIPTION
Added [hook_entity_translation_insert](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Entity%21entity.api.php/function/hook_entity_translation_insert/8.2.x) and [hook_entity_translation_delete](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Entity%21entity.api.php/function/hook_entity_translation_delete/8.2.x).