### PR TITLE
Classname mismatch causes tests failures

### DIFF
--- a/modules/webform_event_dispatcher/tests/src/Unit/WebformElement/WebformElementEventTest.php
+++ b/modules/webform_event_dispatcher/tests/src/Unit/WebformElement/WebformElementEventTest.php
@@ -17,7 +17,7 @@ use Drupal\webform_event_dispatcher\Event\WebformElement\WebformElementTypeAlter
  *
  * @group hook_event_dispatcher
  */
-class WebformFormElementEventTest extends UnitTestCase {
+class WebformElementEventTest extends UnitTestCase {
 
   /**
    * The manager.


### PR DESCRIPTION
https://www.drupal.org/project/hook_event_dispatcher/issues/3052240