### PR TITLE
Update EckEntityPreprocessVariables to new variables structure

### DIFF
--- a/src/Event/Preprocess/Variables/EckEntityEventVariables.php
+++ b/src/Event/Preprocess/Variables/EckEntityEventVariables.php
@@ -14,7 +14,7 @@ class EckEntityEventVariables extends AbstractEntityEventVariables {
    *   EckEntity.
    */
   public function getEckEntity() {
-    return $this->variables['eck_entity'];
+    return $this->variables['entity']['#entity'];
   }
 
   /**
@@ -28,14 +28,14 @@ class EckEntityEventVariables extends AbstractEntityEventVariables {
    * {@inheritdoc}
    */
   public function getEntityBundle() {
-    return $this->variables['bundle'];
+    return $this->variables['entity']['#entity_type'];
   }
 
   /**
    * {@inheritdoc}
    */
   public function getViewMode() {
-    return $this->variables['elements']['#view_mode'];
+    return $this->variables['entity']['#view_mode'];
   }
 
 }

--- a/tests/src/Unit/Preprocess/EntityEventTest.php
+++ b/tests/src/Unit/Preprocess/EntityEventTest.php
@@ -71,12 +71,12 @@ final class EntityEventTest extends UnitTestCase {
    */
   public function testEckEntityEvent() {
     $this->variables = [
-      'elements' => [
+      'entity' => [
+        '#entity' => new EntityMock('eck_entity', 'bundle', 'view_mode'),
+        '#entity_type' => 'bundle',
         '#view_mode' => 'view_mode',
       ],
-      'eck_entity' => new EntityMock('eck_entity', 'bundle', 'view_mode'),
       'theme_hook_original' => 'eck_entity',
-      'bundle' => 'bundle',
     ];
     $this->createAndAssertEntityEvent(EckEntityPreprocessEvent::class);
   }

--- a/tests/src/Unit/Preprocess/EntityEventVariablesTest.php
+++ b/tests/src/Unit/Preprocess/EntityEventVariablesTest.php
@@ -68,12 +68,12 @@ final class EntityEventVariablesTest extends UnitTestCase {
     $eckEntity = new EntityMock('eck_entity', 'eck_entity_bundle', 'eck_entity_view_mode');
     $variablesArray = $this->createVariablesArray();
 
-    $variablesArray['eck_entity'] = $eckEntity;
-    $variablesArray['elements'] = [
+    $variablesArray['entity'] = [
+      '#entity' => $eckEntity,
+      '#entity_type' => $eckEntity->bundle(),
       '#view_mode' => $eckEntity->getViewMode(),
     ];
     $variablesArray['theme_hook_original'] = $eckEntity->getEntityType();
-    $variablesArray['bundle'] = $eckEntity->bundle();
 
     /* @var \Drupal\hook_event_dispatcher\Event\Preprocess\Variables\EckEntityEventVariables $variables */
     $variables = $this->getVariablesFromCreatedEvent(EckEntityPreprocessEvent::class, $variablesArray);


### PR DESCRIPTION
This didn't match anymore so this would throw notices if there where
EckEntities defined. Updated the methods to get the right keys in the
variables array.