### PR TITLE
EntityOperationEvent: fixes fatal error when no operations have defined.

### DIFF
--- a/src/Event/Entity/EntityOperationEvent.php
+++ b/src/Event/Entity/EntityOperationEvent.php
@@ -17,7 +17,7 @@ class EntityOperationEvent extends Event implements EventInterface {
    *
    * @var array
    */
-  private $operations;
+  private $operations = [];
 
   /**
    * The entity.


### PR DESCRIPTION
Bit of a surprise when I went to ```admin/content```. ;)