### PR TITLE
Media event constant now explicitly public; updated @see to submodule.

### DIFF
--- a/src/HookEventDispatcherInterface.php
+++ b/src/HookEventDispatcherInterface.php
@@ -761,11 +761,11 @@ interface HookEventDispatcherInterface {
    *
    * @Event
    *
-   * @see hook_event_dispatcher_oembed_resource_data_alter()
+   * @see media_event_dispatcher_oembed_resource_data_alter()
    * @see hook_oembed_resource_url_alter()
    *
    * @var string
    */
-  const MEDIA_OEMBED_RESOURCE_DATA_ALTER = 'hook_event_dispatcher.media_oembed.url_alter';
+  public const MEDIA_OEMBED_RESOURCE_DATA_ALTER = 'hook_event_dispatcher.media.oembed_url_alter';
 
 }


### PR DESCRIPTION
Just updated the existing constant to the PHP 7 format you're switching to and also updated the ```@see``` which was incorrectly pointing to the now non-existing ```hook_event_dispatcher_oembed_resource_data_alter()```.