### PR TITLE
Added MediaSourceInfoAlterEvent.

### DIFF
--- a/modules/media_event_dispatcher/media_event_dispatcher.module
+++ b/modules/media_event_dispatcher/media_event_dispatcher.module
@@ -5,8 +5,21 @@
  * Media event dispatcher submodule.
  */
 
+use Drupal\media_event_dispatcher\Event\Media\MediaSourceInfoAlterEvent;
 use Drupal\media_event_dispatcher\Event\Media\OEmbedResourceUrlAlterEvent;
 use Drupal\media\OEmbed\Provider;
+
+/**
+ * Implements hook_media_source_info_alter().
+ *
+ * {@inheritdoc}
+ */
+function media_event_dispatcher_media_source_info_alter(array &$sources) {
+  /* @var \Drupal\hook_event_dispatcher\Manager\HookEventDispatcherManagerInterface $manager */
+  $manager = \Drupal::service('hook_event_dispatcher.manager');
+  $event = new MediaSourceInfoAlterEvent($sources);
+  $manager->register($event);
+}
 
 /**
  * Implements hook_oembed_resource_url_alter().

--- a/modules/media_event_dispatcher/src/Event/Media/MediaSourceInfoAlterEvent.php
+++ b/modules/media_event_dispatcher/src/Event/Media/MediaSourceInfoAlterEvent.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\media_event_dispatcher\Event\Media;
+
+use Drupal\hook_event_dispatcher\Event\EventInterface;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class MediaSourceInfoAlterEvent.
+ */
+class MediaSourceInfoAlterEvent extends Event implements EventInterface {
+
+  /**
+   * The array of media source plugin definitions, keyed by plugin ID.
+   *
+   * @var array
+   */
+  private $sources;
+
+  /**
+   * MediaSourceInfoAlterEvent constructor.
+   *
+   * @param array &$sources
+   *   The array of media source plugin definitions, keyed by plugin ID.
+   */
+  public function __construct(array &$sources) {
+    $this->sources = &$sources;
+  }
+
+  /**
+   * Get the media source plugin definitions.
+   *
+   * @return array
+   *   The array of media source plugin definitions, keyed by plugin ID.
+   */
+  public function &getSources(): array {
+    return $this->sources;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDispatcherType(): string {
+    return HookEventDispatcherInterface::MEDIA_SOURCE_INFO_ALTER;
+  }
+
+}

--- a/modules/media_event_dispatcher/tests/src/Unit/Media/MediaSourceInfoAlterEventTest.php
+++ b/modules/media_event_dispatcher/tests/src/Unit/Media/MediaSourceInfoAlterEventTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Drupal\Tests\media_event_dispatcher\Unit\Media;
+
+use Drupal;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
+use Drupal\media_event_dispatcher\Event\Media\MediaSourceInfoAlterEvent;
+use Drupal\Tests\hook_event_dispatcher\Unit\HookEventDispatcherManagerSpy;
+use Drupal\Tests\UnitTestCase;
+use function media_event_dispatcher_media_source_info_alter;
+
+/**
+ * Class MediaSourceInfoAlterEventTest.
+ *
+ * @package Drupal\Tests\media_event_dispatcher\Unit\Media
+ *
+ * @group media_event_dispatcher
+ */
+class MediaSourceInfoAlterEventTest extends UnitTestCase {
+
+  /**
+   * The manager.
+   *
+   * @var \Drupal\Tests\hook_event_dispatcher\Unit\HookEventDispatcherManagerSpy
+   */
+  private $manager;
+
+  /**
+   * Sets up the test.
+   */
+  public function setUp() {
+    $builder = new ContainerBuilder();
+    $this->manager = new HookEventDispatcherManagerSpy();
+    $builder->set('hook_event_dispatcher.manager', $this->manager);
+    $builder->compile();
+    Drupal::setContainer($builder);
+  }
+
+  /**
+   * MediaSourceInfoAlterEvent sources array alter test.
+   *
+   * This tests altering the media source plugin definitions array.
+   */
+  public function testMediaSourceInfoAlter() {
+    $sources = $expectedSources = [
+      'image' => [
+        'id' => 'image',
+        'label' => new TranslatableMarkup('Image'),
+        'description' => new TranslatableMarkup('Use local images for reusable media.'),
+        'class' => 'Drupal\media\Plugin\media\Source\Image',
+        'allowed_field_types' => ['image'],
+      ],
+    ];
+
+    $this->manager->setEventCallbacks([
+      HookEventDispatcherInterface::MEDIA_SOURCE_INFO_ALTER => static function (
+        MediaSourceInfoAlterEvent $event
+      ) {
+        $sources = &$event->getSources();
+
+        $sources['image']['allowed_field_types'][] = 'test';
+      },
+    ]);
+
+    // Run the procedural hook which should trigger the above handler.
+    media_event_dispatcher_media_source_info_alter($sources);
+
+    /** @var \Drupal\media_event_dispatcher\Event\Media\MediaSourceInfoAlterEvent $event */
+    $event = $this->manager->getRegisteredEvent(
+      HookEventDispatcherInterface::MEDIA_SOURCE_INFO_ALTER
+    );
+
+    $this->assertSame($sources, $event->getSources());
+
+    $expectedSources['image']['allowed_field_types'][] = 'test';
+
+    $this->assertSame($expectedSources, $sources);
+  }
+
+}

--- a/src/HookEventDispatcherInterface.php
+++ b/src/HookEventDispatcherInterface.php
@@ -757,6 +757,18 @@ interface HookEventDispatcherInterface {
 
   // MEDIA EVENTS.
   /**
+   * Alters the information provided in \Drupal\media\Annotation\MediaSource.
+   *
+   * @Event
+   *
+   * @see media_event_dispatcher_media_source_info_alter()
+   * @see hook_media_source_info_alter()
+   *
+   * @var string
+   */
+  public const MEDIA_SOURCE_INFO_ALTER = 'hook_event_dispatcher.media.source_info_alter';
+
+  /**
    * Alters an oEmbed resource URL before it is fetched.
    *
    * @Event


### PR DESCRIPTION
See #99 

Question: I'm using TranslatableMarkup in the unit test to match the values of the sources info (labels, descriptions) as Drupal normally provides them, but should I just remove those and use plain strings to keep the test simpler?