### PR TITLE
Rename/base to abstract

### DIFF
--- a/src/Event/Block/BlockBuildAlterEvent.php
+++ b/src/Event/Block/BlockBuildAlterEvent.php
@@ -8,7 +8,7 @@ use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
- * Class EntityInsertEvent.
+ * Class BlockBuildAlterEvent.
  */
 class BlockBuildAlterEvent extends Event implements EventInterface {
 
@@ -26,7 +26,7 @@ class BlockBuildAlterEvent extends Event implements EventInterface {
   private $block;
 
   /**
-   * BaseBlockEvent constructor.
+   * BlockBuildAlterEvent constructor.
    *
    * @param array $build
    *   The build array.

--- a/src/Event/Entity/AbstractEntityEvent.php
+++ b/src/Event/Entity/AbstractEntityEvent.php
@@ -7,7 +7,7 @@ use Drupal\hook_event_dispatcher\Event\EventInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
- * Class BaseEntityEvent.
+ * Class AbstractEntityEvent.
  */
 abstract class AbstractEntityEvent extends Event implements EventInterface {
 
@@ -19,7 +19,7 @@ abstract class AbstractEntityEvent extends Event implements EventInterface {
   protected $entity;
 
   /**
-   * BaseEntityEvent constructor.
+   * AbstractEntityEvent constructor.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The Entity.

--- a/src/Event/Form/AbstractFormEvent.php
+++ b/src/Event/Form/AbstractFormEvent.php
@@ -7,9 +7,9 @@ use Drupal\hook_event_dispatcher\Event\EventInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
- * Class BaseFormEvent.
+ * Class AbstractFormEvent.
  */
-abstract class BaseFormEvent extends Event implements EventInterface {
+abstract class AbstractFormEvent extends Event implements EventInterface {
 
   /**
    * The form.
@@ -31,7 +31,7 @@ abstract class BaseFormEvent extends Event implements EventInterface {
   private $formId;
 
   /**
-   * BaseFormEvent constructor.
+   * AbstractFormEvent constructor.
    *
    * @param array $form
    *   Nested array of form elements that comprise the form.

--- a/src/Event/Form/FormAlterEvent.php
+++ b/src/Event/Form/FormAlterEvent.php
@@ -7,7 +7,7 @@ use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 /**
  * Class FormAlterEvent.
  */
-class FormAlterEvent extends BaseFormEvent {
+class FormAlterEvent extends AbstractFormEvent {
 
   /**
    * {@inheritdoc}

--- a/src/Event/Form/FormBaseAlterEvent.php
+++ b/src/Event/Form/FormBaseAlterEvent.php
@@ -7,7 +7,7 @@ use Drupal\Core\Form\FormStateInterface;
 /**
  * Class FormBaserAlterEvent.
  */
-class FormBaseAlterEvent extends BaseFormEvent {
+class FormBaseAlterEvent extends AbstractFormEvent {
 
   /**
    * The base form id.

--- a/src/Event/Form/FormIdAlterEvent.php
+++ b/src/Event/Form/FormIdAlterEvent.php
@@ -5,7 +5,7 @@ namespace Drupal\hook_event_dispatcher\Event\Form;
 /**
  * Class FormIdAlterEvent.
  */
-class FormIdAlterEvent extends BaseFormEvent {
+class FormIdAlterEvent extends AbstractFormEvent {
 
   /**
    * {@inheritdoc}

--- a/src/Event/Path/AbstractPathEvent.php
+++ b/src/Event/Path/AbstractPathEvent.php
@@ -6,9 +6,9 @@ use Drupal\hook_event_dispatcher\Event\EventInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
- * Class BasePathEvent.
+ * Class AbstractPathEvent.
  */
-abstract class BasePathEvent extends Event implements EventInterface {
+abstract class AbstractPathEvent extends Event implements EventInterface {
 
   /**
    * The source like '/node/1'.
@@ -36,7 +36,7 @@ abstract class BasePathEvent extends Event implements EventInterface {
   private $pid;
 
   /**
-   * BasePathEvent constructor.
+   * AbstractPathEvent constructor.
    *
    * @param array $path
    *   The array structure is identical to that of the return value of

--- a/src/Event/Path/PathDeleteEvent.php
+++ b/src/Event/Path/PathDeleteEvent.php
@@ -7,7 +7,7 @@ use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 /**
  * Class PathDeleteEvent.
  */
-final class PathDeleteEvent extends BasePathEvent {
+final class PathDeleteEvent extends AbstractPathEvent {
 
   /**
    * The redirect.

--- a/src/Event/Path/PathInsertEvent.php
+++ b/src/Event/Path/PathInsertEvent.php
@@ -7,7 +7,7 @@ use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 /**
  * Class PathInsertEvent.
  */
-final class PathInsertEvent extends BasePathEvent {
+final class PathInsertEvent extends AbstractPathEvent {
 
   /**
    * Get the dispatcher type.

--- a/src/Event/Path/PathUpdateEvent.php
+++ b/src/Event/Path/PathUpdateEvent.php
@@ -7,7 +7,7 @@ use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 /**
  * Class UpdatePathEvent.
  */
-final class PathUpdateEvent extends BasePathEvent {
+final class PathUpdateEvent extends AbstractPathEvent {
 
   /**
    * Get the dispatcher type.

--- a/src/Event/Theme/AbstractThemeSuggestionsEvent.php
+++ b/src/Event/Theme/AbstractThemeSuggestionsEvent.php
@@ -6,9 +6,9 @@ use Drupal\hook_event_dispatcher\Event\EventInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
- * Class BaseThemeSuggestionsEvent.
+ * Class AbstractThemeSuggestionsEvent.
  */
-abstract class BaseThemeSuggestionsEvent extends Event implements EventInterface {
+abstract class AbstractThemeSuggestionsEvent extends Event implements EventInterface {
 
   /**
    * Array of suggestions.
@@ -30,7 +30,7 @@ abstract class BaseThemeSuggestionsEvent extends Event implements EventInterface
   private $hook;
 
   /**
-   * BaseThemeSuggestionsEvent constructor.
+   * AbstractThemeSuggestionsEvent constructor.
    *
    * @param array $suggestions
    *   Suggestions.

--- a/src/Event/Theme/ThemeSuggestionsAlterEvent.php
+++ b/src/Event/Theme/ThemeSuggestionsAlterEvent.php
@@ -7,7 +7,7 @@ use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 /**
  * Class ThemeSuggestionsAlterEvent.
  */
-class ThemeSuggestionsAlterEvent extends BaseThemeSuggestionsEvent {
+class ThemeSuggestionsAlterEvent extends AbstractThemeSuggestionsEvent {
 
   /**
    * Returns the hook dispatcher type.

--- a/src/Event/Theme/ThemeSuggestionsAlterIdEvent.php
+++ b/src/Event/Theme/ThemeSuggestionsAlterIdEvent.php
@@ -5,7 +5,7 @@ namespace Drupal\hook_event_dispatcher\Event\Theme;
 /**
  * Class ThemeSuggestionsAlterIdEvent.
  */
-class ThemeSuggestionsAlterIdEvent extends BaseThemeSuggestionsEvent {
+class ThemeSuggestionsAlterIdEvent extends AbstractThemeSuggestionsEvent {
 
   /**
    * Returns the hook dispatcher type.

--- a/src/Event/Views/AbstractViewsEvent.php
+++ b/src/Event/Views/AbstractViewsEvent.php
@@ -7,9 +7,9 @@ use Drupal\views\ViewExecutable;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
- * Class BaseViewsEvent.
+ * Class AbstractViewsEvent.
  */
-abstract class BaseViewsEvent extends Event implements EventInterface {
+abstract class AbstractViewsEvent extends Event implements EventInterface {
 
   /**
    * The view.
@@ -19,7 +19,7 @@ abstract class BaseViewsEvent extends Event implements EventInterface {
   private $view;
 
   /**
-   * ViewsPreExecuteEevent constructor.
+   * AbstractViewsEvent constructor.
    *
    * @param \Drupal\views\ViewExecutable $view
    *   The view.

--- a/src/Event/Views/ViewsPostBuildEvent.php
+++ b/src/Event/Views/ViewsPostBuildEvent.php
@@ -7,7 +7,7 @@ use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 /**
  * Class ViewsPostBuildEvent.
  */
-class ViewsPostBuildEvent extends BaseViewsEvent {
+class ViewsPostBuildEvent extends AbstractViewsEvent {
 
   /**
    * {@inheritdoc}

--- a/src/Event/Views/ViewsPostExecuteEvent.php
+++ b/src/Event/Views/ViewsPostExecuteEvent.php
@@ -7,7 +7,7 @@ use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 /**
  * Class ViewsPostExecuteEvent.
  */
-class ViewsPostExecuteEvent extends BaseViewsEvent {
+class ViewsPostExecuteEvent extends AbstractViewsEvent {
 
   /**
    * {@inheritdoc}

--- a/src/Event/Views/ViewsPostRenderEvent.php
+++ b/src/Event/Views/ViewsPostRenderEvent.php
@@ -9,7 +9,7 @@ use Drupal\views\ViewExecutable;
 /**
  * Class ViewsPostRenderEvent.
  */
-class ViewsPostRenderEvent extends BaseViewsEvent {
+class ViewsPostRenderEvent extends AbstractViewsEvent {
 
   /**
    * A renderable array containing the output of the view.

--- a/src/Event/Views/ViewsPreBuildEvent.php
+++ b/src/Event/Views/ViewsPreBuildEvent.php
@@ -7,7 +7,7 @@ use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 /**
  * Class ViewsPreBuildEvent.
  */
-class ViewsPreBuildEvent extends BaseViewsEvent {
+class ViewsPreBuildEvent extends AbstractViewsEvent {
 
   /**
    * {@inheritdoc}

--- a/src/Event/Views/ViewsPreExecuteEvent.php
+++ b/src/Event/Views/ViewsPreExecuteEvent.php
@@ -7,7 +7,7 @@ use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 /**
  * Class ViewsPreExecuteEvent.
  */
-class ViewsPreExecuteEvent extends BaseViewsEvent {
+class ViewsPreExecuteEvent extends AbstractViewsEvent {
 
   /**
    * {@inheritdoc}

--- a/src/Event/Views/ViewsPreRenderEvent.php
+++ b/src/Event/Views/ViewsPreRenderEvent.php
@@ -7,7 +7,7 @@ use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
 /**
  * Class ViewsPreRenderEvent.
  */
-class ViewsPreRenderEvent extends BaseViewsEvent {
+class ViewsPreRenderEvent extends AbstractViewsEvent {
 
   /**
    * {@inheritdoc}

--- a/src/Event/Views/ViewsPreViewEvent.php
+++ b/src/Event/Views/ViewsPreViewEvent.php
@@ -8,7 +8,7 @@ use Drupal\views\ViewExecutable;
 /**
  * Class ViewsPreRenderEvent.
  */
-class ViewsPreViewEvent extends BaseViewsEvent {
+class ViewsPreViewEvent extends AbstractViewsEvent {
 
   /**
    * Array of arguments passed into the view.

--- a/src/Event/Views/ViewsQueryAlterEvent.php
+++ b/src/Event/Views/ViewsQueryAlterEvent.php
@@ -11,7 +11,7 @@ use Drupal\views\ViewExecutable;
  *
  * @package Drupal\hook_event_dispatcher\Event\Views
  */
-final class ViewsQueryAlterEvent extends BaseViewsEvent {
+final class ViewsQueryAlterEvent extends AbstractViewsEvent {
 
   /**
    * The query.

--- a/src/Event/Views/ViewsQuerySubstitutionsEvent.php
+++ b/src/Event/Views/ViewsQuerySubstitutionsEvent.php
@@ -9,7 +9,7 @@ use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
  *
  * @package Drupal\hook_event_dispatcher\Event\Views
  */
-final class ViewsQuerySubstitutionsEvent extends BaseViewsEvent {
+final class ViewsQuerySubstitutionsEvent extends AbstractViewsEvent {
 
   /**
    * Views query substitutions.


### PR DESCRIPTION
Both Base and Abstract are used as prefix for abstract classes. Rename to abstract as that does describe the class better and base is also used by Drupal.