### PR TITLE
Change EntityPresaveEvent::getOriginalEntity to be nullable

### DIFF
--- a/modules/core_event_dispatcher/src/Event/Entity/EntityPresaveEvent.php
+++ b/modules/core_event_dispatcher/src/Event/Entity/EntityPresaveEvent.php
@@ -15,11 +15,11 @@ class EntityPresaveEvent extends AbstractEntityEvent {
    *
    * @see hook_entity_update()
    *
-   * @return \Drupal\Core\Entity\EntityInterface
+   * @return \Drupal\Core\Entity\EntityInterface|null
    *   The original entity.
    */
-  public function getOriginalEntity(): EntityInterface {
-    return $this->entity->original;
+  public function getOriginalEntity(): ?EntityInterface {
+    return $this->entity->original ?? NULL;
   }
 
   /**

--- a/modules/core_event_dispatcher/tests/src/Unit/Entity/EntityEventTest.php
+++ b/modules/core_event_dispatcher/tests/src/Unit/Entity/EntityEventTest.php
@@ -157,6 +157,20 @@ class EntityEventTest extends UnitTestCase {
   }
 
   /**
+   * Test EntityPresaveEvent without original.
+   */
+  public function testEntityPresaveEventWithoutOriginal(): void {
+    $entity = $this->createMock(EntityInterface::class);
+
+    core_event_dispatcher_entity_presave($entity);
+
+    /* @var \Drupal\core_event_dispatcher\Event\Entity\EntityPresaveEvent $event */
+    $event = $this->manager->getRegisteredEvent(HookEventDispatcherInterface::ENTITY_PRE_SAVE);
+    $this->assertSame($entity, $event->getEntity());
+    $this->assertNull($event->getOriginalEntity());
+  }
+
+  /**
    * Test EntityUpdateEvent.
    */
   public function testEntityUpdateEvent(): void {


### PR DESCRIPTION
The original entity is null when the event is triggered on a pre save
for a new entity. Update the code to handle this gracefully without an
error and a notice.

https://www.drupal.org/project/hook_event_dispatcher/issues/3133867