### PR TITLE
Swap arround ENTITY_EXTRA_FIELD_INFO(_ALTER) const

### DIFF
--- a/src/HookEventDispatcherInterface.php
+++ b/src/HookEventDispatcherInterface.php
@@ -189,7 +189,7 @@ interface HookEventDispatcherInterface {
    *
    * @var string
    */
-  const ENTITY_EXTRA_FIELD_INFO_ALTER = 'hook_event_dispatcher.entity_extra_field.info';
+  const ENTITY_EXTRA_FIELD_INFO = 'hook_event_dispatcher.entity_extra_field.info';
 
   /**
    * Alter "pseudo-field" components on content entities.
@@ -201,7 +201,7 @@ interface HookEventDispatcherInterface {
    *
    * @var string
    */
-  const ENTITY_EXTRA_FIELD_INFO = 'hook_event_dispatcher.entity_extra_field.info_alter';
+  const ENTITY_EXTRA_FIELD_INFO_ALTER = 'hook_event_dispatcher.entity_extra_field.info_alter';
 
   // ENTITY TYPE EVENTS.
   /**


### PR DESCRIPTION
They used the wrong string and had the wrong comment above them.

https://www.drupal.org/project/hook_event_dispatcher/issues/3135182